### PR TITLE
Refactor banking module into home and transfer pages

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -1,114 +1,191 @@
 """Routes for the Lifesim banking system."""
 from __future__ import annotations
 
+from copy import deepcopy
+from typing import Iterable
+
 from flask import render_template
 
 from ..logging_service import log_manager
 from . import bp
 
+ACCOUNTS: list[dict[str, object]] = [
+    {"id": "hand", "name": "Money on Hand", "balance": 280.50, "type": "Liquid Cash"},
+    {
+        "id": "checking",
+        "name": "Checking Account",
+        "balance": 5400.25,
+        "type": "Daily Spending",
+    },
+    {
+        "id": "savings",
+        "name": "Savings Account",
+        "balance": 8200.00,
+        "type": "Emergency Fund",
+    },
+]
 
-@bp.route("/")
-def dashboard():
-    """Display banking overview."""
-    log_manager.record(
-        component="Banking",
-        action="view",
-        level="info",
-        result="success",
-        title="Banking dashboard opened",
-        user_summary="Banking overview displayed for the user.",
-        technical_details="banking.dashboard rendered account summaries and goals.",
-    )
-    accounts = [
-        {"id": "hand", "name": "Money on Hand", "balance": 280.50, "type": "Liquid Cash"},
-        {
-            "id": "checking",
-            "name": "Checking Account",
-            "balance": 5400.25,
-            "type": "Daily Spending",
-        },
-        {
-            "id": "savings",
-            "name": "Savings Account",
-            "balance": 8200.00,
-            "type": "Emergency Fund",
-        },
-    ]
-    account_labels = {account["id"]: account["name"] for account in accounts}
-    transactions = [
-        {
-            "name": "Direct Deposit",
-            "description": "Paycheck from Blue Sky Studios",
-            "amount": 2650.00,
-            "direction": "credit",
-            "account": "checking",
-        },
-        {
-            "name": "Emergency Fund Allocation",
-            "description": "Monthly auto-transfer into savings buffer",
-            "amount": 500.00,
-            "direction": "credit",
-            "account": "savings",
-        },
-        {
-            "name": "Weekend Budget",
-            "description": "Pulled cash from checking for discretionary spending",
-            "amount": 150.00,
-            "direction": "debit",
-            "account": "checking",
-        },
-    ]
-    banking_state = {
-        "balances": {
-            "hand": {"label": account_labels["hand"], "balance": accounts[0]["balance"]},
-            "checking": {
-                "label": account_labels["checking"],
-                "balance": accounts[1]["balance"],
+INITIAL_TRANSACTIONS: list[dict[str, object]] = [
+    {
+        "name": "Cash Allocation",
+        "description": "Wallet deposit into Checking Account",
+        "amount": 2650.00,
+        "direction": "credit",
+        "account": "checking",
+    },
+    {
+        "name": "Cash Allocation",
+        "description": "Wallet deposit into Savings Account",
+        "amount": 500.00,
+        "direction": "credit",
+        "account": "savings",
+    },
+    {
+        "name": "Cash Withdrawal",
+        "description": "Funds moved from Checking Account to cash on hand",
+        "amount": 150.00,
+        "direction": "debit",
+        "account": "checking",
+    },
+]
+
+ACCOUNT_INSIGHTS: list[dict[str, object]] = [
+    {
+        "account": "Money on Hand",
+        "details": [
+            {
+                "label": "Fees",
+                "value": "No direct fees, but untracked spending can cause reconciliation drift.",
             },
-            "savings": {
-                "label": account_labels["savings"],
-                "balance": accounts[2]["balance"],
+            {
+                "label": "Recommended buffer",
+                "value": "Keep at least $200 available for daily cash needs.",
             },
-        },
-        "transactions": transactions,
+        ],
+    },
+    {
+        "account": "Checking Account",
+        "details": [
+            {
+                "label": "Overdraft fee",
+                "value": "$35 per occurrence when the balance dips below $0.",
+            },
+            {
+                "label": "Monthly maintenance",
+                "value": "$5 (waived with a $1,500 average daily balance).",
+            },
+            {
+                "label": "ATM network",
+                "value": "Four out-of-network withdrawals refunded each cycle; $3 thereafter.",
+            },
+        ],
+    },
+    {
+        "account": "Savings Account",
+        "details": [
+            {
+                "label": "Interest rate",
+                "value": "2.10% APY calculated on the monthly average balance.",
+            },
+            {
+                "label": "Transfer allowance",
+                "value": "Three free transfers per month; $8 fee for additional moves.",
+            },
+            {
+                "label": "Minimum balance",
+                "value": "$300 minimum to avoid a $3 low-balance charge.",
+            },
+        ],
+    },
+]
+
+
+def _account_snapshot() -> list[dict[str, object]]:
+    """Return a copy of the configured account balances."""
+    return deepcopy(ACCOUNTS)
+
+
+def _build_banking_state(accounts: Iterable[dict[str, object]]) -> dict[str, object]:
+    """Construct the state payload used by the transfer interface."""
+    account_list = list(accounts)
+    account_labels = {account["id"]: account["name"] for account in account_list}
+    balances = {
+        account["id"]: {"label": account["name"], "balance": account["balance"]}
+        for account in account_list
+    }
+    return {
+        "balances": balances,
+        "transactions": deepcopy(INITIAL_TRANSACTIONS),
         "account_labels": account_labels,
     }
-    goals = [
-        {"goal": "Vacation Fund", "target": 2000, "current": 1200},
-        {"goal": "Student Loan", "target": 15000, "current": 4500},
-    ]
-    for goal in goals:
-        progress = goal['current'] / goal['target'] if goal['target'] else 0
-        if progress < 0.5:
+
+
+def _log_cash_health(accounts: Iterable[dict[str, object]]) -> None:
+    """Emit warnings if liquid cash drops below the healthy threshold."""
+    for account in accounts:
+        if account.get("id") == "hand" and float(account.get("balance", 0)) < 150:
             log_manager.record(
                 component="Banking",
-                action="goal-check",
+                action="cash-check",
                 level="warn",
                 result="warn",
-                title=f"Goal {goal['goal']} behind schedule",
-                user_summary=f"{goal['goal']} is {progress * 100:.0f}% funded. Consider allocating more savings.",
-                technical_details="Banking goals analysis flagged a low funding ratio under 50 percent.",
+                title="Cash on hand trending low",
+                user_summary=(
+                    "Cash on hand fell below $150. Consider moving funds from checking or savings."
+                ),
+                technical_details=(
+                    "banking.cash_monitor detected low liquidity in physical cash reserves."
+                ),
             )
-    if accounts[0]["balance"] < 150:
-        log_manager.record(
-            component="Banking",
-            action="cash-check",
-            level="warn",
-            result="warn",
-            title="Cash on hand trending low",
-            user_summary=(
-                "Cash on hand fell below $150. Consider moving funds from checking or savings."
-            ),
-            technical_details=(
-                "banking.dashboard detected low liquidity in physical cash reserves."
-            ),
-        )
+            break
+
+
+@bp.route("/")
+def home():
+    """Display the banking overview and account information."""
+    log_manager.record(
+        component="Banking",
+        action="view-home",
+        level="info",
+        result="success",
+        title="Banking home opened",
+        user_summary="Banking overview displayed for the player.",
+        technical_details="banking.home rendered account balances and fee breakdowns.",
+    )
+    accounts = _account_snapshot()
+    _log_cash_health(accounts)
 
     return render_template(
-        "banking/dashboard.html",
-        title="Lifesim — Banking",
+        "banking/home.html",
+        title="Lifesim — Banking Home",
         accounts=accounts,
-        goals=goals,
+        account_insights=deepcopy(ACCOUNT_INSIGHTS),
+        active_nav="banking",
+        active_banking_tab="home",
+    )
+
+
+@bp.route("/transfer")
+def transfer():
+    """Surface the cash transfer workflow on a dedicated page."""
+    log_manager.record(
+        component="Banking",
+        action="view-transfer",
+        level="info",
+        result="success",
+        title="Banking transfer center opened",
+        user_summary="Transfer interface loaded for cash and account movements.",
+        technical_details="banking.transfer rendered cash movement forms and ledger.",
+    )
+    accounts = _account_snapshot()
+    banking_state = _build_banking_state(accounts)
+    _log_cash_health(accounts)
+
+    return render_template(
+        "banking/transfer.html",
+        title="Lifesim — Banking Transfer",
+        accounts=accounts,
         banking_state=banking_state,
         active_nav="banking",
+        active_banking_tab="transfer",
     )

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -1,3 +1,50 @@
+.banking-subnav {
+  margin-bottom: clamp(1rem, 3vw, 1.75rem);
+  display: flex;
+  justify-content: center;
+}
+
+.banking-tabs {
+  display: flex;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.banking-tab {
+  color: #e2e8f0;
+  text-decoration: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.banking-tab:hover,
+.banking-tab:focus {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.banking-tab.is-active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(14, 165, 233, 0.85));
+  color: #0f172a;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .banking-tabs {
+    border-radius: 1rem;
+    justify-content: center;
+  }
+
+  .banking-tab {
+    flex: 1 1 45%;
+    text-align: center;
+  }
+}
+
 .banking-overview {
   background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(8, 47, 73, 0.8));
   border-radius: 1.75rem;
@@ -8,6 +55,12 @@
 .banking-overview__header h1 {
   margin: 0 0 0.5rem;
   font-size: clamp(2rem, 3.5vw, 2.8rem);
+}
+
+.banking-overview__header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  max-width: 42rem;
 }
 
 .account-grid {
@@ -67,6 +120,23 @@
 .transfer-card p {
   margin: 0;
   color: rgba(226, 232, 240, 0.8);
+}
+
+.transfer-card__note {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.45;
+}
+
+.transfer-card__summary {
+  margin: 0;
+  background: rgba(30, 64, 175, 0.35);
+  border-radius: 1rem;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  color: #bfdbfe;
 }
 
 .transfer-form {
@@ -130,11 +200,71 @@
   color: #34d399;
 }
 
-.goal-tracker {
+.banking-insights {
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
   background: rgba(15, 23, 42, 0.75);
   border-radius: 1.75rem;
   padding: clamp(1.5rem, 4vw, 3.5rem);
   border: 1px solid rgba(15, 118, 110, 0.35);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.banking-insights header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.insight-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.insight-card {
+  background: rgba(8, 47, 73, 0.6);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(125, 211, 252, 0.3);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.insight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.insight-item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.insight-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.insight-value {
+  color: #e2e8f0;
+  line-height: 1.4;
+}
+
+.insight-footer {
+  border-top: 1px solid rgba(94, 234, 212, 0.25);
+  padding-top: 1rem;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.5;
 }
 
 .transaction-ledger {
@@ -198,57 +328,4 @@
   margin: 0;
   color: rgba(226, 232, 240, 0.75);
   font-style: italic;
-}
-
-.goal-tracker header {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-}
-
-.goal-tracker h2 {
-  margin: 0;
-}
-
-.goal-toggle {
-  background: transparent;
-  border: 1px solid rgba(45, 212, 191, 0.6);
-  color: rgba(209, 250, 229, 0.9);
-  padding: 0.5rem 1.25rem;
-  border-radius: 999px;
-}
-
-.goal-grid {
-  margin-top: 2rem;
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.goal {
-  background: rgba(22, 78, 99, 0.5);
-  border-radius: 1.25rem;
-  padding: 1.25rem;
-  border: 1px solid rgba(45, 212, 191, 0.35);
-  display: grid;
-  gap: 0.5rem;
-}
-
-.goal__progress {
-  height: 10px;
-  background: rgba(15, 23, 42, 0.6);
-  border-radius: 999px;
-  overflow: hidden;
-}
-
-.goal__progress-bar {
-  height: 100%;
-  background: linear-gradient(90deg, #22d3ee, #34d399);
-  width: 0;
-}
-
-.goal.projected .goal__progress-bar {
-  background: linear-gradient(90deg, #fde68a, #f97316);
 }

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -1,0 +1,72 @@
+{% extends "layouts/base.html" %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{{ url_for('banking.static', filename='styles/banking.css') }}" />
+{% endblock %}
+
+{% block content %}
+  <section class="banking-subnav" aria-label="Banking navigation">
+    <nav class="banking-tabs">
+      <a
+        href="{{ url_for('banking.home') }}"
+        class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+        {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+      >
+        Banking Home
+      </a>
+      <a
+        href="{{ url_for('banking.transfer') }}"
+        class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+        {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+      >
+        Banking Transfer
+      </a>
+    </nav>
+  </section>
+
+  <section class="banking-overview">
+    <header class="banking-overview__header">
+      <h1>Lifesim — Banking Home</h1>
+      <p>Review balances at a glance and stay ahead of account fees, interest, and policies.</p>
+    </header>
+    <div class="account-grid">
+      {% for account in accounts %}
+        <article class="account-card" data-account-card data-account="{{ account.id }}">
+          <h2>{{ account.name }}</h2>
+          <p class="account-card__type">{{ account.type }}</p>
+          <p class="account-card__balance">
+            <span data-balance-value>${{ '%.2f'|format(account.balance) }}</span>
+          </p>
+        </article>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="banking-insights" aria-label="Banking information">
+    <header>
+      <h2>Account insights and fees</h2>
+      <p>Know what each account costs, how it earns interest, and the limits that keep you compliant.</p>
+    </header>
+    <div class="insight-grid">
+      {% for insight in account_insights %}
+        <article class="insight-card">
+          <h3>{{ insight.account }}</h3>
+          <ul class="insight-list">
+            {% for detail in insight.details %}
+              <li class="insight-item">
+                <span class="insight-label">{{ detail.label }}</span>
+                <span class="insight-value">{{ detail.value }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </article>
+      {% endfor %}
+    </div>
+    <footer class="insight-footer">
+      <p>
+        Monitor balances weekly to avoid avoidable charges and maximize savings growth. When fees are imminent,
+        shift funds through the transfer hub to rebalance ahead of billing cycles.
+      </p>
+    </footer>
+  </section>
+{% endblock %}

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -9,52 +9,38 @@
 {% endblock %}
 
 {% block content %}
+  <section class="banking-subnav" aria-label="Banking navigation">
+    <nav class="banking-tabs">
+      <a
+        href="{{ url_for('banking.home') }}"
+        class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+        {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+      >
+        Banking Home
+      </a>
+      <a
+        href="{{ url_for('banking.transfer') }}"
+        class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+        {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+      >
+        Banking Transfer
+      </a>
+    </nav>
+  </section>
+
   <section class="banking-overview">
     <header class="banking-overview__header">
-      <h1>Lifesim — Banking</h1>
-      <p>Track liquid funds, shift money between accounts, and log every transfer for full visibility.</p>
+      <h1>Lifesim — Banking Transfer</h1>
+      <p>Move money between cash, checking, and savings while every transaction is automatically described.</p>
     </header>
-    <div class="account-grid">
-      {% for account in accounts %}
-        <article
-          class="account-card"
-          data-account-card
-          data-account="{{ account.id }}"
-          data-balance="{{ '%.2f'|format(account.balance) }}"
-        >
-          <h2>{{ account.name }}</h2>
-          <p class="account-card__type">{{ account.type }}</p>
-          <p class="account-card__balance">
-            <span data-balance-value>${{ '%.2f'|format(account.balance) }}</span>
-          </p>
-        </article>
-      {% endfor %}
-    </div>
     <div class="transfer-panel" aria-label="Manage cash movement">
       <article class="transfer-card">
         <h2>Move cash into accounts</h2>
         <p>Shift money from your wallet into checking or savings and document the transfer.</p>
         <form id="form-hand-to-account" class="transfer-form">
-          <div class="form-row">
-            <label for="hand-transfer-name">Transaction name</label>
-            <input
-              id="hand-transfer-name"
-              name="name"
-              type="text"
-              placeholder="Paycheck deposit"
-              required
-            />
-          </div>
-          <div class="form-row">
-            <label for="hand-transfer-description">Description</label>
-            <input
-              id="hand-transfer-description"
-              name="description"
-              type="text"
-              placeholder="Income moved from cash to checking"
-              required
-            />
-          </div>
+          <p class="transfer-card__note">
+            Transactions from this tool are stored as <strong>Cash Allocation</strong> with the destination documented for you.
+          </p>
           <div class="form-row">
             <label for="hand-transfer-amount">Amount</label>
             <input
@@ -74,6 +60,9 @@
               <option value="savings">Savings</option>
             </select>
           </div>
+          <p class="transfer-card__summary" data-deposit-summary>
+            Cash Allocation — Wallet deposit into the selected account.
+          </p>
           <button type="submit" class="transfer-button">Deposit into account</button>
           <p class="form-feedback" data-feedback hidden></p>
         </form>
@@ -82,26 +71,9 @@
         <h2>Replenish cash on hand</h2>
         <p>Move funds out of checking or savings to give yourself spending flexibility.</p>
         <form id="form-account-to-hand" class="transfer-form">
-          <div class="form-row">
-            <label for="account-withdraw-name">Transaction name</label>
-            <input
-              id="account-withdraw-name"
-              name="name"
-              type="text"
-              placeholder="ATM withdrawal"
-              required
-            />
-          </div>
-          <div class="form-row">
-            <label for="account-withdraw-description">Description</label>
-            <input
-              id="account-withdraw-description"
-              name="description"
-              type="text"
-              placeholder="Moved from checking to wallet"
-              required
-            />
-          </div>
+          <p class="transfer-card__note">
+            This flow records a <strong>Cash Withdrawal</strong> and notes which account supplied the cash.
+          </p>
           <div class="form-row">
             <label for="account-withdraw-amount">Amount</label>
             <input
@@ -121,6 +93,9 @@
               <option value="savings">Savings</option>
             </select>
           </div>
+          <p class="transfer-card__summary" data-withdraw-summary>
+            Cash Withdrawal — Funds moved from the selected account to cash on hand.
+          </p>
           <button type="submit" class="transfer-button">Move funds to cash</button>
           <p class="form-feedback" data-feedback hidden></p>
         </form>
@@ -160,25 +135,6 @@
       <p class="ledger-empty" data-ledger-empty {% if banking_state.transactions %}hidden{% endif %}>
         No transfers recorded yet. Move funds to populate your history.
       </p>
-    </div>
-  </section>
-
-  <section class="goal-tracker" aria-label="Financial goals">
-    <header>
-      <h2>Goals and contributions</h2>
-      <button type="button" class="goal-toggle">Toggle projections</button>
-    </header>
-    <div class="goal-grid">
-      {% for goal in goals %}
-        <article class="goal" data-target="{{ goal.target }}" data-current="{{ goal.current }}">
-          <h3>{{ goal.goal }}</h3>
-          <p>Target: ${{ goal.target }}</p>
-          <p>Current: ${{ goal.current }}</p>
-          <div class="goal__progress" role="progressbar" aria-valuemin="0" aria-valuemax="{{ goal.target }}" aria-valuenow="{{ goal.current }}">
-            <div class="goal__progress-bar"></div>
-          </div>
-        </article>
-      {% endfor %}
     </div>
   </section>
 

--- a/app/index/templates/index/home.html
+++ b/app/index/templates/index/home.html
@@ -14,7 +14,7 @@
       <h1>Lifesim — Home</h1>
       <p>Your life systems at a glance. Track your finances, assets, and work streams in one unified hub.</p>
       <div class="welcome__cta">
-        <a class="cta" href="{{ url_for('banking.dashboard') }}">Review banking health</a>
+        <a class="cta" href="{{ url_for('banking.home') }}">Review banking health</a>
         <a class="cta secondary" href="{{ url_for('real_estate.portfolio') }}">Inspect properties</a>
       </div>
     </div>

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -17,7 +17,7 @@
         </button>
         <nav id="primary-nav" class="primary-nav" aria-label="Main navigation">
           <a href="{{ url_for('index.home') }}" class="nav-item{% if active_nav == 'home' %} active{% endif %}">Home</a>
-          <a href="{{ url_for('banking.dashboard') }}" class="nav-item{% if active_nav == 'banking' %} active{% endif %}">Banking</a>
+          <a href="{{ url_for('banking.home') }}" class="nav-item{% if active_nav == 'banking' %} active{% endif %}">Banking</a>
           <a href="{{ url_for('real_estate.portfolio') }}" class="nav-item{% if active_nav == 'real_estate' %} active{% endif %}">Real Estate</a>
           <a href="{{ url_for('shop.catalog') }}" class="nav-item{% if active_nav == 'shop' %} active{% endif %}">Shop</a>
           <a href="{{ url_for('job.workspace') }}" class="nav-item{% if active_nav == 'job' %} active{% endif %}">Job</a>

--- a/logs.md
+++ b/logs.md
@@ -27,3 +27,15 @@
   provides accountability for every action.
 - **Purpose**: Delivers the envisioned, more complex banking system that tracks liquidity, supports
   cash-to-account transfers, and records each event for future review.
+
+## 2024-04-10
+- **What**: Split the banking experience into a dedicated home page and transfer center, removed the
+  deprecated goals section, and introduced preset descriptions for cash movements alongside a fees and
+  interest briefing.
+- **How**: Added new templates for the banking home and transfer pages, updated the blueprint routes
+  and assets to serve the new structure, reworked the JavaScript to rely on automatic transaction
+  narratives, and refreshed the banking styles with navigation and insight layouts.
+- **Why**: The banking module needed clearer navigation, automated transfer labeling, and explicit
+  account policy messaging to match the updated product direction.
+- **Purpose**: Gives players a streamlined money hub that highlights balances, surfaces fees before
+  they post, and keeps every transfer consistently documented.


### PR DESCRIPTION
## Summary
- create a dedicated banking home page that surfaces balances alongside fee and interest insights
- move the transfer workflow to its own /banking/transfer route with automatic transaction narratives
- refresh banking assets and navigation to remove the legacy goals flow and support the new structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfbc86a14c8321b5e51e3aab263cd7