### PR TITLE
Add banking settings management with database-backed transfers

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,10 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     log_manager.init_app(app)
 
     with app.app_context():
+        # Import models to ensure they are registered before table creation.
+        from . import models as core_models  # noqa: F401
+        from .banking import models as banking_models  # noqa: F401
+
         db.create_all()
 
     from .index import bp as index_bp

--- a/app/banking/models.py
+++ b/app/banking/models.py
@@ -1,0 +1,62 @@
+"""Database models for the banking system."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import CheckConstraint
+
+from ..extensions import db
+
+
+class BankSettings(db.Model):
+    """Persisted configuration for the banking system."""
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    bank_name: str = db.Column(db.String(120), nullable=False, default="Lifesim Bank")
+    standard_fee: Decimal = db.Column(db.Numeric(10, 2), nullable=False, default=Decimal("5.00"))
+    savings_interest_rate: Decimal = db.Column(
+        db.Numeric(5, 3), nullable=False, default=Decimal("2.100")
+    )
+    created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
+class BankAccount(db.Model):
+    """Represents a single bank account tracked by the player."""
+
+    __table_args__ = (
+        CheckConstraint("balance >= 0", name="ck_bank_account_balance_positive"),
+    )
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    slug: str = db.Column(db.String(32), unique=True, nullable=False, index=True)
+    name: str = db.Column(db.String(120), nullable=False)
+    category: str = db.Column(db.String(64), nullable=False)
+    balance: Decimal = db.Column(db.Numeric(12, 2), nullable=False, default=Decimal("0.00"))
+    created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
+class BankTransaction(db.Model):
+    """Ledger entry for money moving in or out of an account."""
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    account_id: int = db.Column(db.Integer, db.ForeignKey("bank_account.id"), nullable=False)
+    name: str = db.Column(db.String(120), nullable=False)
+    description: str = db.Column(db.Text, nullable=False)
+    direction: str = db.Column(db.String(16), nullable=False)
+    amount: Decimal = db.Column(db.Numeric(12, 2), nullable=False)
+    created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    account = db.relationship("BankAccount", backref="transactions")
+
+    __table_args__ = (
+        CheckConstraint(
+            "direction IN ('credit', 'debit')", name="ck_bank_transaction_direction"
+        ),
+    )

--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -1,129 +1,47 @@
-"""Routes for the Lifesim banking system."""
+"""Routes for the Lifesim banking system backed by the database."""
 from __future__ import annotations
 
-from copy import deepcopy
+from decimal import Decimal
 from typing import Iterable
 
-from flask import render_template
+from flask import jsonify, render_template, request
+from sqlalchemy.exc import SQLAlchemyError
 
+from ..extensions import db
 from ..logging_service import log_manager
 from . import bp
-
-ACCOUNTS: list[dict[str, object]] = [
-    {"id": "hand", "name": "Money on Hand", "balance": 280.50, "type": "Liquid Cash"},
-    {
-        "id": "checking",
-        "name": "Checking Account",
-        "balance": 5400.25,
-        "type": "Daily Spending",
-    },
-    {
-        "id": "savings",
-        "name": "Savings Account",
-        "balance": 8200.00,
-        "type": "Emergency Fund",
-    },
-]
-
-INITIAL_TRANSACTIONS: list[dict[str, object]] = [
-    {
-        "name": "Cash Allocation",
-        "description": "Wallet deposit into Checking Account",
-        "amount": 2650.00,
-        "direction": "credit",
-        "account": "checking",
-    },
-    {
-        "name": "Cash Allocation",
-        "description": "Wallet deposit into Savings Account",
-        "amount": 500.00,
-        "direction": "credit",
-        "account": "savings",
-    },
-    {
-        "name": "Cash Withdrawal",
-        "description": "Funds moved from Checking Account to cash on hand",
-        "amount": 150.00,
-        "direction": "debit",
-        "account": "checking",
-    },
-]
-
-ACCOUNT_INSIGHTS: list[dict[str, object]] = [
-    {
-        "account": "Money on Hand",
-        "details": [
-            {
-                "label": "Fees",
-                "value": "No direct fees, but untracked spending can cause reconciliation drift.",
-            },
-            {
-                "label": "Recommended buffer",
-                "value": "Keep at least $200 available for daily cash needs.",
-            },
-        ],
-    },
-    {
-        "account": "Checking Account",
-        "details": [
-            {
-                "label": "Overdraft fee",
-                "value": "$35 per occurrence when the balance dips below $0.",
-            },
-            {
-                "label": "Monthly maintenance",
-                "value": "$5 (waived with a $1,500 average daily balance).",
-            },
-            {
-                "label": "ATM network",
-                "value": "Four out-of-network withdrawals refunded each cycle; $3 thereafter.",
-            },
-        ],
-    },
-    {
-        "account": "Savings Account",
-        "details": [
-            {
-                "label": "Interest rate",
-                "value": "2.10% APY calculated on the monthly average balance.",
-            },
-            {
-                "label": "Transfer allowance",
-                "value": "Three free transfers per month; $8 fee for additional moves.",
-            },
-            {
-                "label": "Minimum balance",
-                "value": "$300 minimum to avoid a $3 low-balance charge.",
-            },
-        ],
-    },
-]
+from .models import BankAccount, BankTransaction
+from .services import (
+    build_account_insights,
+    build_banking_state,
+    ensure_bank_defaults,
+    fetch_accounts,
+    find_account,
+    format_currency,
+    get_bank_settings,
+    normalize_interest_rate,
+    quantize_amount,
+    update_account_balance,
+)
 
 
-def _account_snapshot() -> list[dict[str, object]]:
-    """Return a copy of the configured account balances."""
-    return deepcopy(ACCOUNTS)
+def _serialize_account(account: BankAccount) -> dict[str, object]:
+    """Prepare account details for template rendering."""
 
-
-def _build_banking_state(accounts: Iterable[dict[str, object]]) -> dict[str, object]:
-    """Construct the state payload used by the transfer interface."""
-    account_list = list(accounts)
-    account_labels = {account["id"]: account["name"] for account in account_list}
-    balances = {
-        account["id"]: {"label": account["name"], "balance": account["balance"]}
-        for account in account_list
-    }
     return {
-        "balances": balances,
-        "transactions": deepcopy(INITIAL_TRANSACTIONS),
-        "account_labels": account_labels,
+        "id": account.slug,
+        "name": account.name,
+        "type": account.category,
+        "balance": float(quantize_amount(account.balance)),
+        "display_balance": format_currency(account.balance),
     }
 
 
-def _log_cash_health(accounts: Iterable[dict[str, object]]) -> None:
+def _log_cash_health(accounts: Iterable[BankAccount]) -> None:
     """Emit warnings if liquid cash drops below the healthy threshold."""
+
     for account in accounts:
-        if account.get("id") == "hand" and float(account.get("balance", 0)) < 150:
+        if account.slug == "hand" and account.balance < Decimal("150"):
             log_manager.record(
                 component="Banking",
                 action="cash-check",
@@ -140,9 +58,29 @@ def _log_cash_health(accounts: Iterable[dict[str, object]]) -> None:
             break
 
 
+def _json_response(payload: dict[str, object], *, status: int = 200):
+    """Return a JSON response with a consistent structure."""
+
+    response = jsonify(payload)
+    response.status_code = status
+    return response
+
+
+def _json_error(message: str, *, status: int = 400):
+    """Return a JSON error payload with the supplied status."""
+
+    return _json_response({"success": False, "message": message}, status=status)
+
+
 @bp.route("/")
 def home():
     """Display the banking overview and account information."""
+
+    ensure_bank_defaults()
+    settings = get_bank_settings()
+    accounts = fetch_accounts()
+    _log_cash_health(accounts)
+
     log_manager.record(
         component="Banking",
         action="view-home",
@@ -152,14 +90,16 @@ def home():
         user_summary="Banking overview displayed for the player.",
         technical_details="banking.home rendered account balances and fee breakdowns.",
     )
-    accounts = _account_snapshot()
-    _log_cash_health(accounts)
+
+    serialized_accounts = [_serialize_account(account) for account in accounts]
+    insights = build_account_insights(settings)
 
     return render_template(
         "banking/home.html",
         title="Lifesim — Banking Home",
-        accounts=accounts,
-        account_insights=deepcopy(ACCOUNT_INSIGHTS),
+        accounts=serialized_accounts,
+        account_insights=insights,
+        bank_settings=settings,
         active_nav="banking",
         active_banking_tab="home",
     )
@@ -168,6 +108,13 @@ def home():
 @bp.route("/transfer")
 def transfer():
     """Surface the cash transfer workflow on a dedicated page."""
+
+    ensure_bank_defaults()
+    settings = get_bank_settings()
+    accounts = fetch_accounts()
+    banking_state = build_banking_state()
+    _log_cash_health(accounts)
+
     log_manager.record(
         component="Banking",
         action="view-transfer",
@@ -177,15 +124,471 @@ def transfer():
         user_summary="Transfer interface loaded for cash and account movements.",
         technical_details="banking.transfer rendered cash movement forms and ledger.",
     )
-    accounts = _account_snapshot()
-    banking_state = _build_banking_state(accounts)
-    _log_cash_health(accounts)
+
+    serialized_accounts = [_serialize_account(account) for account in accounts]
 
     return render_template(
         "banking/transfer.html",
         title="Lifesim — Banking Transfer",
-        accounts=accounts,
+        accounts=serialized_accounts,
         banking_state=banking_state,
+        bank_settings=settings,
         active_nav="banking",
         active_banking_tab="transfer",
     )
+
+
+@bp.post("/api/transfer/deposit")
+def api_deposit():
+    """Move money from cash on hand into a selected account."""
+
+    ensure_bank_defaults()
+    payload = request.get_json(silent=True) or {}
+    destination_slug = (payload.get("destination") or "").strip()
+    amount_raw = payload.get("amount")
+
+    try:
+        amount = quantize_amount(amount_raw)
+    except (ValueError, TypeError):
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="error",
+            result="error",
+            title="Deposit rejected — invalid amount",
+            user_summary="Transfer could not be processed because the amount was invalid.",
+            technical_details="banking.api_deposit rejected payload due to invalid numeric input.",
+        )
+        return _json_error("Enter a valid deposit amount.")
+
+    if amount <= 0:
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="warn",
+            result="error",
+            title="Deposit rejected — non-positive amount",
+            user_summary="Transfer amount must be greater than zero.",
+            technical_details="banking.api_deposit received a non-positive amount.",
+        )
+        return _json_error("Deposit amount must be greater than zero.")
+
+    destination = find_account(destination_slug)
+    hand = find_account("hand")
+
+    if not destination:
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="error",
+            result="error",
+            title="Deposit rejected — unknown destination",
+            user_summary="Select a valid account to receive the deposit.",
+            technical_details=f"banking.api_deposit failed because destination '{destination_slug}' was missing.",
+        )
+        return _json_error("Select a valid destination account.")
+
+    if not hand:
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="error",
+            result="error",
+            title="Deposit rejected — cash account missing",
+            user_summary="Cash on hand account is unavailable.",
+            technical_details="banking.api_deposit could not locate the cash on hand account.",
+        )
+        return _json_error("Cash on hand balance is unavailable.")
+
+    if amount > hand.balance:
+        available = format_currency(hand.balance)
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="warn",
+            result="error",
+            title="Deposit rejected — insufficient cash",
+            user_summary=f"Only {available} available in cash on hand.",
+            technical_details="banking.api_deposit prevented overdrawing the cash on hand account.",
+        )
+        return _json_error(f"Only {available} available in cash on hand.")
+
+    description = f"Wallet deposit into {destination.name}"
+
+    try:
+        with db.session.begin():
+            hand.balance = quantize_amount(hand.balance - amount)
+            destination.balance = quantize_amount(destination.balance + amount)
+            db.session.add(hand)
+            db.session.add(destination)
+            db.session.add(
+                BankTransaction(
+                    account=destination,
+                    name="Cash Allocation",
+                    description=description,
+                    direction="credit",
+                    amount=amount,
+                )
+            )
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        log_manager.record(
+            component="Banking",
+            action="deposit",
+            level="error",
+            result="error",
+            title="Deposit failed — database error",
+            user_summary="The deposit could not be saved. Try again shortly.",
+            technical_details=f"banking.api_deposit encountered {exc.__class__.__name__}: {exc}",
+        )
+        return _json_error("Unable to complete the deposit at this time.", status=500)
+
+    state = build_banking_state()
+    _log_cash_health(fetch_accounts())
+
+    log_manager.record(
+        component="Banking",
+        action="deposit",
+        level="info",
+        result="success",
+        title="Cash deposited",
+        user_summary=f"Moved {format_currency(amount)} to {destination.name}.",
+        technical_details=(
+            "banking.api_deposit updated account balances and created a credit transaction entry."
+        ),
+    )
+
+    message = f"Transferred {format_currency(amount)} to {destination.name}."
+    return _json_response({"success": True, "message": message, "state": state})
+
+
+@bp.post("/api/transfer/withdraw")
+def api_withdraw():
+    """Move money from an account back into cash on hand."""
+
+    ensure_bank_defaults()
+    payload = request.get_json(silent=True) or {}
+    source_slug = (payload.get("source") or "").strip()
+    amount_raw = payload.get("amount")
+
+    try:
+        amount = quantize_amount(amount_raw)
+    except (ValueError, TypeError):
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="error",
+            result="error",
+            title="Withdrawal rejected — invalid amount",
+            user_summary="Transfer could not be processed because the amount was invalid.",
+            technical_details="banking.api_withdraw rejected payload due to invalid numeric input.",
+        )
+        return _json_error("Enter a valid withdrawal amount.")
+
+    if amount <= 0:
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="warn",
+            result="error",
+            title="Withdrawal rejected — non-positive amount",
+            user_summary="Transfer amount must be greater than zero.",
+            technical_details="banking.api_withdraw received a non-positive amount.",
+        )
+        return _json_error("Withdrawal amount must be greater than zero.")
+
+    source = find_account(source_slug)
+    hand = find_account("hand")
+
+    if not source:
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="error",
+            result="error",
+            title="Withdrawal rejected — unknown source",
+            user_summary="Select a valid account to withdraw from.",
+            technical_details=f"banking.api_withdraw failed because source '{source_slug}' was missing.",
+        )
+        return _json_error("Select a valid source account.")
+
+    if not hand:
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="error",
+            result="error",
+            title="Withdrawal rejected — cash account missing",
+            user_summary="Cash on hand account is unavailable.",
+            technical_details="banking.api_withdraw could not locate the cash on hand account.",
+        )
+        return _json_error("Cash on hand balance is unavailable.")
+
+    if amount > source.balance:
+        available = format_currency(source.balance)
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="warn",
+            result="error",
+            title="Withdrawal rejected — insufficient funds",
+            user_summary=f"{source.name} only has {available} available.",
+            technical_details="banking.api_withdraw prevented overdrawing the source account.",
+        )
+        return _json_error(f"{source.name} only has {available} available.")
+
+    description = f"Funds moved from {source.name} to cash on hand"
+
+    try:
+        with db.session.begin():
+            source.balance = quantize_amount(source.balance - amount)
+            hand.balance = quantize_amount(hand.balance + amount)
+            db.session.add(source)
+            db.session.add(hand)
+            db.session.add(
+                BankTransaction(
+                    account=source,
+                    name="Cash Withdrawal",
+                    description=description,
+                    direction="debit",
+                    amount=amount,
+                )
+            )
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        log_manager.record(
+            component="Banking",
+            action="withdraw",
+            level="error",
+            result="error",
+            title="Withdrawal failed — database error",
+            user_summary="The withdrawal could not be saved. Try again shortly.",
+            technical_details=f"banking.api_withdraw encountered {exc.__class__.__name__}: {exc}",
+        )
+        return _json_error("Unable to complete the withdrawal at this time.", status=500)
+
+    state = build_banking_state()
+    _log_cash_health(fetch_accounts())
+
+    log_manager.record(
+        component="Banking",
+        action="withdraw",
+        level="info",
+        result="success",
+        title="Cash withdrawn",
+        user_summary=f"Moved {format_currency(amount)} from {source.name} to cash on hand.",
+        technical_details=(
+            "banking.api_withdraw updated account balances and created a debit transaction entry."
+        ),
+    )
+
+    message = f"Moved {format_currency(amount)} from {source.name} to cash on hand."
+    return _json_response({"success": True, "message": message, "state": state})
+
+
+@bp.route("/settings", methods=["GET", "POST"])
+def settings():
+    """Allow administrators to adjust bank configuration and balances."""
+
+    ensure_bank_defaults()
+    settings = get_bank_settings()
+    accounts = fetch_accounts()
+    feedback: dict[str, str] | None = None
+
+    if request.method == "GET":
+        log_manager.record(
+            component="Banking",
+            action="view-settings",
+            level="info",
+            result="success",
+            title="Banking settings opened",
+            user_summary="Bank configuration interface displayed for adjustments.",
+            technical_details="banking.settings rendered configuration and balance controls.",
+        )
+
+    if request.method == "POST":
+        intent = request.form.get("intent")
+
+        if intent == "update-settings":
+            feedback = _handle_settings_update(settings)
+        elif intent == "update-balance":
+            feedback = _handle_balance_update(accounts)
+        elif intent == "reset-balance":
+            feedback = _handle_balance_reset(accounts)
+        else:
+            feedback = {
+                "type": "error",
+                "message": "Unsupported action requested.",
+            }
+
+        settings = get_bank_settings()
+        accounts = fetch_accounts()
+
+    _log_cash_health(accounts)
+
+    serialized_accounts = [_serialize_account(account) for account in accounts]
+
+    return render_template(
+        "banking/settings.html",
+        title="Lifesim — Banking Settings",
+        bank_settings=settings,
+        accounts=serialized_accounts,
+        feedback=feedback,
+        active_nav="banking",
+        active_banking_tab="settings",
+    )
+
+
+def _handle_settings_update(settings) -> dict[str, str]:
+    """Persist updates to the bank name, fee, and interest rate."""
+
+    bank_name = (request.form.get("bank_name") or "").strip()
+    fee_raw = request.form.get("standard_fee")
+    interest_raw = request.form.get("savings_interest_rate")
+
+    errors: list[str] = []
+
+    if not bank_name:
+        errors.append("Provide a name for the banking system.")
+
+    try:
+        fee_amount = quantize_amount(fee_raw)
+        if fee_amount < 0:
+            raise ValueError
+    except (ValueError, TypeError):
+        errors.append("Enter a valid, non-negative fee amount.")
+        fee_amount = settings.standard_fee
+
+    try:
+        interest_rate = normalize_interest_rate(interest_raw)
+        if interest_rate < 0:
+            raise ValueError
+    except (ValueError, TypeError):
+        errors.append("Enter a valid, non-negative savings interest rate.")
+        interest_rate = settings.savings_interest_rate
+
+    if errors:
+        return {"type": "error", "message": " ".join(errors)}
+
+    try:
+        with db.session.begin():
+            settings.bank_name = bank_name
+            settings.standard_fee = fee_amount
+            settings.savings_interest_rate = interest_rate
+            db.session.add(settings)
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        log_manager.record(
+            component="Banking",
+            action="update-settings",
+            level="error",
+            result="error",
+            title="Settings update failed",
+            user_summary="Bank settings could not be saved.",
+            technical_details=f"banking._handle_settings_update encountered {exc.__class__.__name__}: {exc}",
+        )
+        return {"type": "error", "message": "Unable to update settings at this time."}
+
+    log_manager.record(
+        component="Banking",
+        action="update-settings",
+        level="info",
+        result="success",
+        title="Bank settings updated",
+        user_summary=f"Bank renamed to {bank_name} with fee {format_currency(fee_amount)} and interest {interest_rate:.3f}%.",
+        technical_details="banking._handle_settings_update committed new configuration values.",
+    )
+
+    return {
+        "type": "success",
+        "message": "Bank settings saved successfully.",
+    }
+
+
+def _handle_balance_update(accounts: Iterable[BankAccount]) -> dict[str, str]:
+    """Update an individual account balance based on form data."""
+
+    account_slug = request.form.get("account_id")
+    amount_raw = request.form.get("amount")
+
+    target = next((acc for acc in accounts if acc.slug == account_slug), None)
+    if not target:
+        return {"type": "error", "message": "Select a valid account to update."}
+
+    try:
+        amount = quantize_amount(amount_raw)
+        if amount < 0:
+            raise ValueError
+    except (ValueError, TypeError):
+        return {"type": "error", "message": "Enter a valid, non-negative amount."}
+
+    try:
+        with db.session.begin():
+            update_account_balance(target, amount)
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        log_manager.record(
+            component="Banking",
+            action="update-balance",
+            level="error",
+            result="error",
+            title="Balance update failed",
+            user_summary=f"Could not update {target.name} balance.",
+            technical_details=f"banking._handle_balance_update encountered {exc.__class__.__name__}: {exc}",
+        )
+        return {"type": "error", "message": "Unable to update the balance at this time."}
+
+    log_manager.record(
+        component="Banking",
+        action="update-balance",
+        level="info",
+        result="success",
+        title="Account balance updated",
+        user_summary=f"Set {target.name} to {format_currency(amount)}.",
+        technical_details="banking._handle_balance_update committed a manual balance change.",
+    )
+
+    return {
+        "type": "success",
+        "message": f"{target.name} updated to {format_currency(amount)}.",
+    }
+
+
+def _handle_balance_reset(accounts: Iterable[BankAccount]) -> dict[str, str]:
+    """Reset an account balance to zero."""
+
+    account_slug = request.form.get("account_id")
+    target = next((acc for acc in accounts if acc.slug == account_slug), None)
+    if not target:
+        return {"type": "error", "message": "Select a valid account to reset."}
+
+    try:
+        with db.session.begin():
+            update_account_balance(target, Decimal("0"))
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        log_manager.record(
+            component="Banking",
+            action="reset-balance",
+            level="error",
+            result="error",
+            title="Balance reset failed",
+            user_summary=f"Could not reset {target.name}.",
+            technical_details=f"banking._handle_balance_reset encountered {exc.__class__.__name__}: {exc}",
+        )
+        return {"type": "error", "message": "Unable to reset the balance at this time."}
+
+    log_manager.record(
+        component="Banking",
+        action="reset-balance",
+        level="info",
+        result="success",
+        title="Account balance reset",
+        user_summary=f"Reset {target.name} to $0.00.",
+        technical_details="banking._handle_balance_reset committed a zero-balance update.",
+    )
+
+    return {
+        "type": "success",
+        "message": f"{target.name} reset to $0.00.",
+    }

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -1,0 +1,259 @@
+"""Helper utilities for banking data management."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any
+
+from sqlalchemy import select
+
+from ..extensions import db
+from .models import BankAccount, BankSettings, BankTransaction
+
+DEFAULT_ACCOUNTS: tuple[dict[str, Any], ...] = (
+    {
+        "slug": "hand",
+        "name": "Money on Hand",
+        "category": "Liquid Cash",
+        "balance": Decimal("280.50"),
+    },
+    {
+        "slug": "checking",
+        "name": "Checking Account",
+        "category": "Daily Spending",
+        "balance": Decimal("5400.25"),
+    },
+    {
+        "slug": "savings",
+        "name": "Savings Account",
+        "category": "Emergency Fund",
+        "balance": Decimal("8200.00"),
+    },
+)
+
+DEFAULT_TRANSACTIONS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "Cash Allocation",
+        "description": "Wallet deposit into Checking Account",
+        "amount": Decimal("2650.00"),
+        "direction": "credit",
+        "account_slug": "checking",
+    },
+    {
+        "name": "Cash Allocation",
+        "description": "Wallet deposit into Savings Account",
+        "amount": Decimal("500.00"),
+        "direction": "credit",
+        "account_slug": "savings",
+    },
+    {
+        "name": "Cash Withdrawal",
+        "description": "Funds moved from Checking Account to cash on hand",
+        "amount": Decimal("150.00"),
+        "direction": "debit",
+        "account_slug": "checking",
+    },
+)
+
+
+def quantize_amount(value: Decimal | float | str) -> Decimal:
+    """Normalize values to two decimal places."""
+
+    if isinstance(value, Decimal):
+        amount = value
+    else:
+        try:
+            amount = Decimal(str(value))
+        except (InvalidOperation, TypeError) as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid numeric value") from exc
+    return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def decimal_to_number(value: Decimal | float | int) -> float:
+    """Convert decimals to floats for JSON serialization."""
+
+    if isinstance(value, Decimal):
+        return float(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+    return float(value)
+
+
+def ensure_bank_defaults() -> BankSettings:
+    """Ensure banking defaults exist before interacting with the system."""
+
+    settings = BankSettings.query.first()
+    created = False
+
+    if not settings:
+        settings = BankSettings()
+        db.session.add(settings)
+        created = True
+
+    accounts_by_slug = {account.slug: account for account in BankAccount.query.all()}
+
+    for config in DEFAULT_ACCOUNTS:
+        if config["slug"] not in accounts_by_slug:
+            account = BankAccount(
+                slug=config["slug"],
+                name=config["name"],
+                category=config["category"],
+                balance=quantize_amount(config["balance"]),
+            )
+            db.session.add(account)
+            accounts_by_slug[account.slug] = account
+            created = True
+
+    if BankTransaction.query.count() == 0:
+        for entry in DEFAULT_TRANSACTIONS:
+            account = accounts_by_slug.get(entry["account_slug"])
+            if not account:
+                continue
+            transaction = BankTransaction(
+                account=account,
+                name=entry["name"],
+                description=entry["description"],
+                amount=quantize_amount(entry["amount"]),
+                direction=entry["direction"],
+            )
+            db.session.add(transaction)
+        created = True
+
+    if created:
+        db.session.commit()
+
+    return settings
+
+
+def fetch_accounts() -> list[BankAccount]:
+    """Return all bank accounts sorted by creation order."""
+
+    return list(BankAccount.query.order_by(BankAccount.created_at.asc()).all())
+
+
+def build_banking_state(limit: int = 20) -> dict[str, Any]:
+    """Return the structured state used by the transfer interface."""
+
+    accounts = fetch_accounts()
+    balances = {
+        account.slug: {
+            "label": account.name,
+            "balance": decimal_to_number(account.balance),
+        }
+        for account in accounts
+    }
+
+    transactions = (
+        db.session.execute(
+            select(BankTransaction)
+            .order_by(BankTransaction.created_at.desc())
+            .limit(limit)
+        )
+        .scalars()
+        .all()
+    )
+
+    ledger = [
+        {
+            "name": transaction.name,
+            "description": transaction.description,
+            "amount": decimal_to_number(transaction.amount),
+            "direction": transaction.direction,
+            "account": transaction.account.slug,
+        }
+        for transaction in transactions
+    ]
+
+    return {
+        "balances": balances,
+        "transactions": ledger,
+        "account_labels": {account.slug: account.name for account in accounts},
+    }
+
+
+def build_account_insights(settings: BankSettings) -> list[dict[str, Any]]:
+    """Construct insight content for the overview page."""
+
+    fee_display = format_currency(settings.standard_fee)
+    interest_display = f"{decimal_to_number(settings.savings_interest_rate):.2f}% APY"
+
+    return [
+        {
+            "account": "Money on Hand",
+            "details": [
+                {
+                    "label": "Cash buffer",
+                    "value": "Keep at least $200 to cover day-to-day expenses without dipping into accounts.",
+                },
+                {
+                    "label": "Reconciliation",
+                    "value": "Log every cash purchase so deposits back into checking stay accurate.",
+                },
+            ],
+        },
+        {
+            "account": "Checking Account",
+            "details": [
+                {
+                    "label": "Monthly service fee",
+                    "value": f"A {fee_display} service charge applies when the balance falls under $1,500.",
+                },
+                {
+                    "label": "Transaction guidance",
+                    "value": "Schedule bill payments from checking to avoid surprise cash shortfalls.",
+                },
+            ],
+        },
+        {
+            "account": "Savings Account",
+            "details": [
+                {
+                    "label": "Interest rate",
+                    "value": f"Savings grows at {interest_display} calculated on the average monthly balance.",
+                },
+                {
+                    "label": "Transfer allowance",
+                    "value": "Limit yourself to three outgoing transfers each month to avoid penalties.",
+                },
+            ],
+        },
+    ]
+
+
+def format_currency(amount: Decimal | float | str) -> str:
+    """Return a currency formatted string for display content."""
+
+    quantized = quantize_amount(amount)
+    return f"${quantized:,.2f}"
+
+
+def find_account(slug: str) -> BankAccount | None:
+    """Return the requested account, if it exists."""
+
+    if not slug:
+        return None
+    return BankAccount.query.filter_by(slug=slug).first()
+
+
+def update_account_balance(account: BankAccount, amount: Decimal) -> None:
+    """Persist a new balance for the provided account."""
+
+    account.balance = quantize_amount(amount)
+    db.session.add(account)
+
+
+def normalize_interest_rate(value: Decimal | float | str) -> Decimal:
+    """Normalize interest rate inputs to three decimal places."""
+
+    if isinstance(value, Decimal):
+        rate = value
+    else:
+        try:
+            rate = Decimal(str(value))
+        except (InvalidOperation, TypeError) as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid numeric value") from exc
+    return rate.quantize(Decimal("0.001"), rounding=ROUND_HALF_UP)
+
+def get_bank_settings() -> BankSettings:
+    """Retrieve banking settings ensuring defaults are initialized."""
+
+    ensure_bank_defaults()
+    return BankSettings.query.first()

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -1,5 +1,12 @@
+.banking-shell {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  padding-bottom: clamp(2rem, 5vw, 3rem);
+}
+
 .banking-subnav {
-  margin-bottom: clamp(1rem, 3vw, 1.75rem);
   display: flex;
   justify-content: center;
 }
@@ -7,30 +14,31 @@
 .banking-tabs {
   display: flex;
   gap: 0.75rem;
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 999px;
   padding: 0.35rem;
   flex-wrap: wrap;
 }
 
 .banking-tab {
-  color: #e2e8f0;
+  color: var(--muted);
   text-decoration: none;
   padding: 0.5rem 1.25rem;
   border-radius: 999px;
+  font-weight: 600;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .banking-tab:hover,
 .banking-tab:focus {
-  background: rgba(59, 130, 246, 0.2);
+  background: var(--surface-alt);
+  color: var(--text);
 }
 
 .banking-tab.is-active {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(14, 165, 233, 0.85));
-  color: #0f172a;
-  font-weight: 600;
+  background: var(--accent);
+  color: #ffffff;
 }
 
 @media (max-width: 640px) {
@@ -45,98 +53,112 @@
   }
 }
 
-.banking-overview {
-  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(8, 47, 73, 0.8));
-  border-radius: 1.75rem;
-  padding: clamp(1.5rem, 4vw, 3.5rem);
-  border: 1px solid rgba(56, 189, 248, 0.25);
+.banking-overview,
+.transaction-ledger,
+.settings-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .banking-overview__header h1 {
   margin: 0 0 0.5rem;
-  font-size: clamp(2rem, 3.5vw, 2.8rem);
+  font-size: clamp(2rem, 4vw, 2.6rem);
 }
 
 .banking-overview__header p {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
-  max-width: 42rem;
+  color: var(--muted);
+  max-width: 44rem;
+  line-height: 1.55;
 }
 
 .account-grid {
-  margin-top: 2rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .account-card {
-  background: rgba(30, 64, 175, 0.35);
-  border-radius: 1.5rem;
-  padding: 1.5rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
   display: grid;
   gap: 0.75rem;
-  border: 1px solid rgba(191, 219, 254, 0.25);
-  transition: transform 0.2s ease;
 }
 
-.account-card:hover,
-.account-card:focus {
-  transform: translateY(-4px);
+.account-card header {
+  display: grid;
+  gap: 0.25rem;
 }
 
 .account-card__type {
-  color: rgba(226, 232, 240, 0.75);
   margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .account-card__balance {
-  font-size: clamp(1.6rem, 3vw, 2.2rem);
   margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.2rem);
   font-variant-numeric: tabular-nums;
 }
 
+.account-card__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .transfer-panel {
-  margin-top: clamp(2rem, 4vw, 3rem);
   display: grid;
-  gap: 1.5rem;
+  gap: clamp(1.5rem, 3vw, 2rem);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .transfer-card {
-  background: rgba(8, 47, 73, 0.65);
-  border-radius: 1.5rem;
-  border: 1px solid rgba(125, 211, 252, 0.3);
-  padding: 1.5rem;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
   display: grid;
   gap: 1rem;
 }
 
 .transfer-card h2 {
   margin: 0;
-  font-size: clamp(1.25rem, 2.4vw, 1.6rem);
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
 }
 
 .transfer-card p {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  color: var(--muted);
+  line-height: 1.5;
 }
 
 .transfer-card__note {
-  background: rgba(15, 23, 42, 0.6);
-  border-radius: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
   padding: 0.75rem 1rem;
-  color: rgba(226, 232, 240, 0.85);
-  line-height: 1.45;
+  background: var(--surface);
+  color: var(--text);
 }
 
 .transfer-card__summary {
   margin: 0;
-  background: rgba(30, 64, 175, 0.35);
-  border-radius: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
   padding: 0.75rem 1rem;
   font-weight: 600;
-  color: #bfdbfe;
+  color: var(--text);
+  background: var(--surface);
 }
 
 .transfer-form {
@@ -155,35 +177,63 @@
 }
 
 .transfer-form input,
-.transfer-form select {
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(125, 211, 252, 0.35);
+.transfer-form select,
+.settings-form input,
+.settings-account-form input {
+  border: 1px solid var(--border);
   border-radius: 0.75rem;
-  color: #e2e8f0;
+  padding: 0.6rem 0.75rem;
   font: inherit;
-  padding: 0.65rem 0.75rem;
+  color: var(--text);
+  background: var(--surface);
 }
 
 .transfer-form input:focus,
-.transfer-form select:focus {
-  outline: 2px solid rgba(14, 165, 233, 0.7);
+.transfer-form select:focus,
+.settings-form input:focus,
+.settings-account-form input:focus {
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-.transfer-button {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.8), rgba(14, 165, 233, 0.8));
+.transfer-button,
+.settings-submit,
+.settings-account-save,
+.settings-account-reset {
   border: none;
-  color: #f8fafc;
-  padding: 0.75rem 1.5rem;
   border-radius: 999px;
+  padding: 0.7rem 1.4rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.transfer-button,
+.settings-submit,
+.settings-account-save {
+  background: var(--accent);
+  color: #ffffff;
 }
 
 .transfer-button:hover,
-.transfer-button:focus {
-  transform: translateY(-1px);
+.transfer-button:focus,
+.settings-submit:hover,
+.settings-submit:focus,
+.settings-account-save:hover,
+.settings-account-save:focus {
+  background: var(--accent-alt);
+}
+
+.settings-account-reset {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.settings-account-reset:hover,
+.settings-account-reset:focus {
+  color: var(--text);
+  border-color: var(--accent);
 }
 
 .form-feedback {
@@ -193,46 +243,46 @@
 }
 
 .form-feedback[data-state="error"] {
-  color: #f87171;
+  color: var(--error);
 }
 
 .form-feedback[data-state="success"] {
-  color: #34d399;
+  color: var(--success);
 }
 
 .banking-insights {
-  margin-top: clamp(2.5rem, 5vw, 3.5rem);
-  background: rgba(15, 23, 42, 0.75);
-  border-radius: 1.75rem;
-  padding: clamp(1.5rem, 4vw, 3.5rem);
-  border: 1px solid rgba(15, 118, 110, 0.35);
   display: grid;
-  gap: 1.75rem;
+  gap: clamp(1.5rem, 3vw, 2rem);
 }
 
-.banking-insights header {
-  display: grid;
-  gap: 0.5rem;
+.banking-insights header h2 {
+  margin: 0 0 0.5rem;
+}
+
+.banking-insights header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 42rem;
+  line-height: 1.55;
 }
 
 .insight-grid {
   display: grid;
-  gap: 1.5rem;
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .insight-card {
-  background: rgba(8, 47, 73, 0.6);
-  border-radius: 1.5rem;
-  border: 1px solid rgba(125, 211, 252, 0.3);
-  padding: 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .insight-card h3 {
   margin: 0;
-  font-size: 1.15rem;
 }
 
 .insight-list {
@@ -245,41 +295,38 @@
 
 .insight-item {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.25rem;
 }
 
 .insight-label {
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  color: var(--muted);
 }
 
 .insight-value {
-  color: #e2e8f0;
-  line-height: 1.4;
-}
-
-.insight-footer {
-  border-top: 1px solid rgba(94, 234, 212, 0.25);
-  padding-top: 1rem;
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--text);
   line-height: 1.5;
 }
 
-.transaction-ledger {
-  margin-top: clamp(2.5rem, 5vw, 3.5rem);
-  background: rgba(15, 23, 42, 0.8);
-  border-radius: 1.75rem;
-  padding: clamp(1.5rem, 4vw, 3.5rem);
-  border: 1px solid rgba(96, 165, 250, 0.35);
-  display: grid;
-  gap: 1.5rem;
+.insight-footer {
+  margin: 0;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  color: var(--muted);
+  line-height: 1.55;
 }
 
-.transaction-ledger header {
-  display: grid;
-  gap: 0.5rem;
+.transaction-ledger header h2 {
+  margin: 0 0 0.5rem;
+}
+
+.transaction-ledger header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 36rem;
+  line-height: 1.55;
 }
 
 .transaction-ledger__table {
@@ -294,16 +341,16 @@
 
 .transaction-table th,
 .transaction-table td {
-  padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .transaction-table th {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: rgba(226, 232, 240, 0.85);
+  letter-spacing: 0.05em;
+  color: var(--muted);
 }
 
 .transaction-table__amount,
@@ -313,19 +360,149 @@
 }
 
 .transaction-amount.credit {
-  color: #34d399;
+  color: var(--success);
 }
 
 .transaction-amount.debit {
-  color: #f87171;
+  color: var(--error);
 }
 
 .transaction-table tbody tr:nth-child(even) {
-  background: rgba(30, 58, 138, 0.2);
+  background: var(--surface-alt);
 }
 
 .ledger-empty {
   margin: 0;
-  color: rgba(226, 232, 240, 0.75);
+  color: var(--muted);
   font-style: italic;
+}
+
+.settings-intro {
+  display: grid;
+  gap: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+}
+
+.settings-intro h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.4rem);
+}
+
+.settings-intro p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.settings-note {
+  margin: 0;
+  color: var(--muted);
+}
+
+.settings-alert {
+  border-radius: 1rem;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid transparent;
+  font-weight: 600;
+}
+
+.settings-alert--success {
+  background: rgba(21, 128, 61, 0.08);
+  color: var(--success);
+  border-color: rgba(21, 128, 61, 0.2);
+}
+
+.settings-alert--error {
+  background: rgba(185, 28, 28, 0.08);
+  color: var(--error);
+  border-color: rgba(185, 28, 28, 0.2);
+}
+
+.settings-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.settings-form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-input {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.settings-input .prefix,
+.settings-input .suffix {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.settings-account-grid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.settings-account-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.settings-account-card header h3 {
+  margin: 0;
+}
+
+.settings-account-type {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.settings-account-balance {
+  margin: 0;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.settings-account-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.settings-account-form label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-account-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+  }
 }

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -5,68 +5,85 @@
 {% endblock %}
 
 {% block content %}
-  <section class="banking-subnav" aria-label="Banking navigation">
-    <nav class="banking-tabs">
-      <a
-        href="{{ url_for('banking.home') }}"
-        class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
-        {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
-      >
-        Banking Home
-      </a>
-      <a
-        href="{{ url_for('banking.transfer') }}"
-        class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-        {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-      >
-        Banking Transfer
-      </a>
-    </nav>
-  </section>
+  <div class="banking-shell">
+    <section class="banking-subnav" aria-label="Banking navigation">
+      <nav class="banking-tabs">
+        <a
+          href="{{ url_for('banking.home') }}"
+          class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+          {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+        >
+          Banking Home
+        </a>
+        <a
+          href="{{ url_for('banking.transfer') }}"
+          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+        >
+          Banking Transfer
+        </a>
+        <a
+          href="{{ url_for('banking.settings') }}"
+          class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
+          {% if active_banking_tab == 'settings' %}aria-current="page"{% endif %}
+        >
+          Banking Settings
+        </a>
+      </nav>
+    </section>
 
-  <section class="banking-overview">
-    <header class="banking-overview__header">
-      <h1>Lifesim — Banking Home</h1>
-      <p>Review balances at a glance and stay ahead of account fees, interest, and policies.</p>
-    </header>
-    <div class="account-grid">
-      {% for account in accounts %}
-        <article class="account-card" data-account-card data-account="{{ account.id }}">
-          <h2>{{ account.name }}</h2>
-          <p class="account-card__type">{{ account.type }}</p>
-          <p class="account-card__balance">
-            <span data-balance-value>${{ '%.2f'|format(account.balance) }}</span>
-          </p>
-        </article>
-      {% endfor %}
-    </div>
-  </section>
+    <section class="banking-overview">
+      <header class="banking-overview__header">
+        <h1>Lifesim — Banking Home</h1>
+        <p>
+          {{ bank_settings.bank_name }} keeps your cash, checking, and savings balances synchronized so every
+          decision is recorded and visible.
+        </p>
+      </header>
+      <div class="account-grid">
+        {% for account in accounts %}
+          <article class="account-card" data-account-card data-account="{{ account.id }}">
+            <header>
+              <p class="account-card__type">{{ account.type }}</p>
+              <h2>{{ account.name }}</h2>
+            </header>
+            <p class="account-card__balance">
+              <span data-balance-value>{{ account.display_balance }}</span>
+            </p>
+            <p class="account-card__hint">Balances update instantly after each transfer.</p>
+          </article>
+        {% endfor %}
+      </div>
+    </section>
 
-  <section class="banking-insights" aria-label="Banking information">
-    <header>
-      <h2>Account insights and fees</h2>
-      <p>Know what each account costs, how it earns interest, and the limits that keep you compliant.</p>
-    </header>
-    <div class="insight-grid">
-      {% for insight in account_insights %}
-        <article class="insight-card">
-          <h3>{{ insight.account }}</h3>
-          <ul class="insight-list">
-            {% for detail in insight.details %}
-              <li class="insight-item">
-                <span class="insight-label">{{ detail.label }}</span>
-                <span class="insight-value">{{ detail.value }}</span>
-              </li>
-            {% endfor %}
-          </ul>
-        </article>
-      {% endfor %}
-    </div>
-    <footer class="insight-footer">
-      <p>
-        Monitor balances weekly to avoid avoidable charges and maximize savings growth. When fees are imminent,
-        shift funds through the transfer hub to rebalance ahead of billing cycles.
-      </p>
-    </footer>
-  </section>
+    <section class="banking-insights" aria-label="Banking information">
+      <header>
+        <h2>Account insights and fees</h2>
+        <p>
+          Use the live ledger to act before fees or penalties hit and to capture the interest your savings earns.
+        </p>
+      </header>
+      <div class="insight-grid">
+        {% for insight in account_insights %}
+          <article class="insight-card">
+            <h3>{{ insight.account }}</h3>
+            <ul class="insight-list">
+              {% for detail in insight.details %}
+                <li class="insight-item">
+                  <span class="insight-label">{{ detail.label }}</span>
+                  <span class="insight-value">{{ detail.value }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          </article>
+        {% endfor %}
+      </div>
+      <footer class="insight-footer">
+        <p>
+          Monitor balances weekly and rebalance through the transfer hub ahead of billing cycles. Captured
+          transactions double as an audit trail for every move.
+        </p>
+      </footer>
+    </section>
+  </div>
 {% endblock %}

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -1,0 +1,144 @@
+{% extends "layouts/base.html" %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{{ url_for('banking.static', filename='styles/banking.css') }}" />
+{% endblock %}
+
+{% block content %}
+  <div class="banking-shell">
+    <section class="banking-subnav" aria-label="Banking navigation">
+      <nav class="banking-tabs">
+        <a
+          href="{{ url_for('banking.home') }}"
+          class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+          {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+        >
+          Banking Home
+        </a>
+        <a
+          href="{{ url_for('banking.transfer') }}"
+          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+        >
+          Banking Transfer
+        </a>
+        <a
+          href="{{ url_for('banking.settings') }}"
+          class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
+          {% if active_banking_tab == 'settings' %}aria-current="page"{% endif %}
+        >
+          Banking Settings
+        </a>
+      </nav>
+    </section>
+
+    <section class="settings-intro">
+      <header>
+        <h1>Lifesim — Banking Settings</h1>
+        <p>
+          Configure {{ bank_settings.bank_name }} by defining fees, savings interest, and how much money sits in each
+          account.
+        </p>
+      </header>
+      <p class="settings-note">
+        All changes are logged for auditing, and the ledger will reflect new balances immediately.
+      </p>
+    </section>
+
+    {% if feedback %}
+      <div class="settings-alert settings-alert--{{ feedback.type }}" role="status">
+        {{ feedback.message }}
+      </div>
+    {% endif %}
+
+    <section class="settings-panel" aria-label="Bank configuration">
+      <header>
+        <h2>Bank configuration</h2>
+        <p>Update the system name, the standard service fee, and savings interest.</p>
+      </header>
+      <form method="post" class="settings-form">
+        <input type="hidden" name="intent" value="update-settings" />
+        <div class="settings-grid">
+          <label>
+            <span>Bank name</span>
+            <input
+              type="text"
+              name="bank_name"
+              value="{{ bank_settings.bank_name }}"
+              required
+              maxlength="120"
+            />
+          </label>
+          <label>
+            <span>Monthly service fee</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="standard_fee"
+                value="{{ '%.2f'|format(bank_settings.standard_fee) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
+            <span>Savings interest rate (APY)</span>
+            <div class="settings-input">
+              <input
+                type="number"
+                name="savings_interest_rate"
+                value="{{ '%.3f'|format(bank_settings.savings_interest_rate) }}"
+                min="0"
+                step="0.001"
+                required
+              />
+              <span class="suffix">%</span>
+            </div>
+          </label>
+        </div>
+        <button type="submit" class="settings-submit">Save bank settings</button>
+      </form>
+    </section>
+
+    <section class="settings-panel" aria-label="Account balances">
+      <header>
+        <h2>Manage account balances</h2>
+        <p>Set a new balance or reset an account to zero. Checking and savings accept manual overrides.</p>
+      </header>
+      <div class="settings-account-grid">
+        {% for account in accounts %}
+          <article class="settings-account-card">
+            <header>
+              <h3>{{ account.name }}</h3>
+              <p class="settings-account-type">{{ account.type }}</p>
+            </header>
+            <p class="settings-account-balance">Current balance: <strong>{{ account.display_balance }}</strong></p>
+            <form method="post" class="settings-account-form">
+              <input type="hidden" name="account_id" value="{{ account.id }}" />
+              <label for="balance-{{ account.id }}">Set balance</label>
+              <input
+                id="balance-{{ account.id }}"
+                type="number"
+                name="amount"
+                value="{{ '%.2f'|format(account.balance) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+              <div class="settings-account-actions">
+                <button type="submit" name="intent" value="update-balance" class="settings-account-save">
+                  Save new amount
+                </button>
+                <button type="submit" name="intent" value="reset-balance" class="settings-account-reset">
+                  Reset to $0
+                </button>
+              </div>
+            </form>
+          </article>
+        {% endfor %}
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -9,134 +9,154 @@
 {% endblock %}
 
 {% block content %}
-  <section class="banking-subnav" aria-label="Banking navigation">
-    <nav class="banking-tabs">
-      <a
-        href="{{ url_for('banking.home') }}"
-        class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
-        {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
-      >
-        Banking Home
-      </a>
-      <a
-        href="{{ url_for('banking.transfer') }}"
-        class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-        {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-      >
-        Banking Transfer
-      </a>
-    </nav>
-  </section>
+  <div class="banking-shell">
+    <section class="banking-subnav" aria-label="Banking navigation">
+      <nav class="banking-tabs">
+        <a
+          href="{{ url_for('banking.home') }}"
+          class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+          {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+        >
+          Banking Home
+        </a>
+        <a
+          href="{{ url_for('banking.transfer') }}"
+          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+        >
+          Banking Transfer
+        </a>
+        <a
+          href="{{ url_for('banking.settings') }}"
+          class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
+          {% if active_banking_tab == 'settings' %}aria-current="page"{% endif %}
+        >
+          Banking Settings
+        </a>
+      </nav>
+    </section>
 
-  <section class="banking-overview">
-    <header class="banking-overview__header">
-      <h1>Lifesim — Banking Transfer</h1>
-      <p>Move money between cash, checking, and savings while every transaction is automatically described.</p>
-    </header>
-    <div class="transfer-panel" aria-label="Manage cash movement">
-      <article class="transfer-card">
-        <h2>Move cash into accounts</h2>
-        <p>Shift money from your wallet into checking or savings and document the transfer.</p>
-        <form id="form-hand-to-account" class="transfer-form">
-          <p class="transfer-card__note">
-            Transactions from this tool are stored as <strong>Cash Allocation</strong> with the destination documented for you.
-          </p>
-          <div class="form-row">
-            <label for="hand-transfer-amount">Amount</label>
-            <input
-              id="hand-transfer-amount"
-              name="amount"
-              type="number"
-              min="0.01"
-              step="0.01"
-              required
-            />
-          </div>
-          <div class="form-row">
-            <label for="hand-transfer-destination">Destination</label>
-            <select id="hand-transfer-destination" name="destination" required>
-              <option value="" disabled selected>Select an account</option>
-              <option value="checking">Checking</option>
-              <option value="savings">Savings</option>
-            </select>
-          </div>
-          <p class="transfer-card__summary" data-deposit-summary>
-            Cash Allocation — Wallet deposit into the selected account.
-          </p>
-          <button type="submit" class="transfer-button">Deposit into account</button>
-          <p class="form-feedback" data-feedback hidden></p>
-        </form>
-      </article>
-      <article class="transfer-card">
-        <h2>Replenish cash on hand</h2>
-        <p>Move funds out of checking or savings to give yourself spending flexibility.</p>
-        <form id="form-account-to-hand" class="transfer-form">
-          <p class="transfer-card__note">
-            This flow records a <strong>Cash Withdrawal</strong> and notes which account supplied the cash.
-          </p>
-          <div class="form-row">
-            <label for="account-withdraw-amount">Amount</label>
-            <input
-              id="account-withdraw-amount"
-              name="amount"
-              type="number"
-              min="0.01"
-              step="0.01"
-              required
-            />
-          </div>
-          <div class="form-row">
-            <label for="account-withdraw-source">Source</label>
-            <select id="account-withdraw-source" name="source" required>
-              <option value="" disabled selected>Select an account</option>
-              <option value="checking">Checking</option>
-              <option value="savings">Savings</option>
-            </select>
-          </div>
-          <p class="transfer-card__summary" data-withdraw-summary>
-            Cash Withdrawal — Funds moved from the selected account to cash on hand.
-          </p>
-          <button type="submit" class="transfer-button">Move funds to cash</button>
-          <p class="form-feedback" data-feedback hidden></p>
-        </form>
-      </article>
-    </div>
-  </section>
+    <section class="banking-overview">
+      <header class="banking-overview__header">
+        <h1>Lifesim — Banking Transfer</h1>
+        <p>
+          Move money through {{ bank_settings.bank_name }} while every transaction is written to the ledger and the
+          balances refresh in real time.
+        </p>
+      </header>
+      <div class="transfer-panel" aria-label="Manage cash movement">
+        <article class="transfer-card">
+          <h2>Move cash into accounts</h2>
+          <p>Shift money from your wallet into checking or savings. The ledger records the destination.</p>
+          <form
+            id="form-hand-to-account"
+            class="transfer-form"
+            data-endpoint="{{ url_for('banking.api_deposit') }}"
+          >
+            <p class="transfer-card__note">
+              Transactions from this tool are stored as <strong>Cash Allocation</strong> with the account noted for you.
+            </p>
+            <div class="form-row">
+              <label for="hand-transfer-amount">Amount</label>
+              <input
+                id="hand-transfer-amount"
+                name="amount"
+                type="number"
+                min="0.01"
+                step="0.01"
+                required
+              />
+            </div>
+            <div class="form-row">
+              <label for="hand-transfer-destination">Destination</label>
+              <select id="hand-transfer-destination" name="destination" required>
+                <option value="" disabled selected>Select an account</option>
+                <option value="checking">Checking</option>
+                <option value="savings">Savings</option>
+              </select>
+            </div>
+            <p class="transfer-card__summary" data-deposit-summary>
+              Cash Allocation — Wallet deposit into the selected account.
+            </p>
+            <button type="submit" class="transfer-button">Deposit into account</button>
+            <p class="form-feedback" data-feedback hidden></p>
+          </form>
+        </article>
+        <article class="transfer-card">
+          <h2>Replenish cash on hand</h2>
+          <p>Move funds out of checking or savings to keep spending money within reach.</p>
+          <form
+            id="form-account-to-hand"
+            class="transfer-form"
+            data-endpoint="{{ url_for('banking.api_withdraw') }}"
+          >
+            <p class="transfer-card__note">
+              This flow records a <strong>Cash Withdrawal</strong> and notes which account supplied the cash.
+            </p>
+            <div class="form-row">
+              <label for="account-withdraw-amount">Amount</label>
+              <input
+                id="account-withdraw-amount"
+                name="amount"
+                type="number"
+                min="0.01"
+                step="0.01"
+                required
+              />
+            </div>
+            <div class="form-row">
+              <label for="account-withdraw-source">Source</label>
+              <select id="account-withdraw-source" name="source" required>
+                <option value="" disabled selected>Select an account</option>
+                <option value="checking">Checking</option>
+                <option value="savings">Savings</option>
+              </select>
+            </div>
+            <p class="transfer-card__summary" data-withdraw-summary>
+              Cash Withdrawal — Funds moved from the selected account to cash on hand.
+            </p>
+            <button type="submit" class="transfer-button">Move funds to cash</button>
+            <p class="form-feedback" data-feedback hidden></p>
+          </form>
+        </article>
+      </div>
+    </section>
 
-  <section class="transaction-ledger" aria-label="Account transfer history">
-    <header>
-      <h2>Transfer log</h2>
-      <p>Every deposit or withdrawal with its story, so you always know where the money went.</p>
-    </header>
-    <div class="transaction-ledger__table">
-      <table class="transaction-table">
-        <thead>
-          <tr>
-            <th scope="col">Name</th>
-            <th scope="col">Description</th>
-            <th scope="col">Account</th>
-            <th scope="col" class="transaction-table__amount">Amount</th>
-          </tr>
-        </thead>
-        <tbody data-ledger-body>
-          {% for transaction in banking_state.transactions %}
-            {% set sign = '+' if transaction.direction == 'credit' else '−' %}
-            <tr data-direction="{{ transaction.direction }}">
-              <td>{{ transaction.name }}</td>
-              <td>{{ transaction.description }}</td>
-              <td>{{ banking_state.account_labels[transaction.account] }}</td>
-              <td class="transaction-amount {{ transaction.direction }}">
-                {{ sign }}${{ '%.2f'|format(transaction.amount) }}
-              </td>
+    <section class="transaction-ledger" aria-label="Account transfer history">
+      <header>
+        <h2>Transfer log</h2>
+        <p>Every deposit or withdrawal is tracked with the account, direction, and amount.</p>
+      </header>
+      <div class="transaction-ledger__table">
+        <table class="transaction-table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Description</th>
+              <th scope="col">Account</th>
+              <th scope="col" class="transaction-table__amount">Amount</th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      <p class="ledger-empty" data-ledger-empty {% if banking_state.transactions %}hidden{% endif %}>
-        No transfers recorded yet. Move funds to populate your history.
-      </p>
-    </div>
-  </section>
+          </thead>
+          <tbody data-ledger-body>
+            {% for transaction in banking_state.transactions %}
+              {% set sign = '+' if transaction.direction == 'credit' else '−' %}
+              <tr data-direction="{{ transaction.direction }}">
+                <td>{{ transaction.name }}</td>
+                <td>{{ transaction.description }}</td>
+                <td>{{ banking_state.account_labels[transaction.account] }}</td>
+                <td class="transaction-amount {{ transaction.direction }}">
+                  {{ sign }}${{ '%.2f'|format(transaction.amount) }}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <p class="ledger-empty" data-ledger-empty {% if banking_state.transactions %}hidden{% endif %}>
+          No transfers recorded yet. Move funds to populate your history.
+        </p>
+      </div>
+    </section>
+  </div>
 
   <script id="banking-data" type="application/json">{{ banking_state | tojson }}</script>
 {% endblock %}

--- a/app/static/styles/base.css
+++ b/app/static/styles/base.css
@@ -1,14 +1,16 @@
 :root {
-  --background: #0f172a;
-  --surface: #111827;
-  --surface-alt: #1f2937;
-  --accent: #38bdf8;
-  --accent-alt: #f97316;
-  --text: #f8fafc;
-  --muted: #94a3b8;
-  --success: #34d399;
-  --warn: #facc15;
-  --error: #f87171;
+  --background: #f5f7fb;
+  --surface: #ffffff;
+  --surface-alt: #f1f5f9;
+  --border: #d4dbe8;
+  --accent: #2563eb;
+  --accent-alt: #1d4ed8;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --text: #0f172a;
+  --muted: #475569;
+  --success: #15803d;
+  --warn: #b45309;
+  --error: #b91c1c;
   font-family: "Inter", "Segoe UI", system-ui, sans-serif;
 }
 
@@ -18,7 +20,7 @@
 
 body {
   margin: 0;
-  background: linear-gradient(135deg, var(--surface) 0%, var(--surface-alt) 100%);
+  background: var(--background);
   color: var(--text);
 }
 
@@ -32,51 +34,54 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
-  background: rgba(15, 23, 42, 0.9);
+  padding: 1rem clamp(1.25rem, 4vw, 2.5rem);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(6px);
 }
 
 .brand {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--accent);
 }
 
 .nav-toggle {
   display: none;
   background: transparent;
-  border: 2px solid var(--accent);
+  border: 1px solid var(--accent);
   color: var(--accent);
-  padding: 0.4rem 0.8rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
+  font-weight: 600;
 }
 
 .primary-nav {
   display: flex;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .nav-item {
   text-decoration: none;
   color: var(--muted);
-  padding: 0.4rem 0.8rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
+  font-weight: 600;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .nav-item:hover,
 .nav-item:focus {
   color: var(--text);
-  background: rgba(56, 189, 248, 0.15);
+  background: var(--accent-soft);
 }
 
 .nav-item.active {
   background: var(--accent);
-  color: #0f172a;
+  color: #ffffff;
 }
 
 .environment {
@@ -86,22 +91,22 @@ body {
 
 .content {
   flex: 1;
-  padding: 2rem clamp(1rem, 5vw, 3rem);
-  display: grid;
-  gap: 2rem;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.25rem, 5vw, 3rem);
+  display: block;
 }
 
 .log-console {
-  background: rgba(17, 24, 39, 0.96);
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 1.5rem;
-  transition: max-height 0.3s ease;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding: 1.5rem clamp(1.25rem, 5vw, 3rem);
+  transition: max-height 0.3s ease, padding 0.3s ease;
   overflow: hidden;
 }
 
 .log-console.closed {
   max-height: 0;
-  padding: 0 1.5rem;
+  padding-top: 0;
+  padding-bottom: 0;
   border-top: none;
 }
 
@@ -112,8 +117,13 @@ body {
   gap: 1rem;
 }
 
+.log-console__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
 .log-filters {
-  margin-top: 1rem;
+  margin-top: 1.25rem;
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -124,15 +134,17 @@ body {
   gap: 0.35rem;
   font-size: 0.85rem;
   color: var(--muted);
+  font-weight: 600;
 }
 
 .log-filters input,
 .log-filters select {
-  padding: 0.5rem;
+  padding: 0.5rem 0.6rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  background: var(--surface);
   color: var(--text);
+  font: inherit;
 }
 
 .log-results {
@@ -143,10 +155,11 @@ body {
 
 .log-entry {
   border-radius: 1rem;
-  padding: 1rem;
-  background: rgba(30, 41, 59, 0.9);
+  padding: 1rem 1.1rem;
+  background: var(--surface-alt);
   display: grid;
   gap: 0.75rem;
+  border: 1px solid var(--border);
 }
 
 .log-entry__header {
@@ -154,6 +167,7 @@ body {
   justify-content: space-between;
   gap: 1rem;
   font-weight: 600;
+  color: var(--text);
 }
 
 .log-entry__meta {
@@ -166,11 +180,13 @@ body {
 
 .log-entry__technical {
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.8);
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 0.75rem;
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 0.8rem;
   position: relative;
+  color: var(--text);
 }
 
 .log-entry__technical button {
@@ -181,7 +197,9 @@ body {
   background: transparent;
   color: var(--accent);
   border-radius: 0.5rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.6rem;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 .log-entry.info {
@@ -208,17 +226,19 @@ body {
 .toast {
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  background: rgba(30, 41, 59, 0.95);
-  border-left: 4px solid var(--accent);
+  background: var(--surface);
+  border: 1px solid var(--border);
   min-width: 220px;
+  color: var(--text);
+  font-weight: 600;
 }
 
 .toast.warn {
-  border-left-color: var(--warn);
+  border-color: rgba(180, 83, 9, 0.4);
 }
 
 .toast.error {
-  border-left-color: var(--error);
+  border-color: rgba(185, 28, 28, 0.4);
 }
 
 @media (max-width: 900px) {
@@ -227,10 +247,9 @@ body {
     inset: 100% 0 auto 0;
     display: none;
     flex-direction: column;
-    background: rgba(15, 23, 42, 0.95);
-    padding: 1rem 1.5rem;
-    border-bottom-left-radius: 1rem;
-    border-bottom-right-radius: 1rem;
+    background: var(--surface);
+    padding: 1rem clamp(1.25rem, 5vw, 3rem);
+    border-bottom: 1px solid var(--border);
   }
 
   .primary-nav.open {
@@ -246,6 +265,16 @@ body {
   }
 }
 
+.log-empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+.toast.fade {
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -254,9 +283,4 @@ body {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
   }
-}
-
-.toast.fade {
-  opacity: 0;
-  transition: opacity 0.4s ease;
 }

--- a/logs.md
+++ b/logs.md
@@ -39,3 +39,16 @@
   account policy messaging to match the updated product direction.
 - **Purpose**: Gives players a streamlined money hub that highlights balances, surfaces fees before
   they post, and keeps every transfer consistently documented.
+
+## 2024-04-11
+- **What**: Migrated the banking system to the database, added a configurable settings console, and
+  refreshed the banking UI for a bright theme with a wider container.
+- **How**: Introduced SQLAlchemy models for bank settings, accounts, and transactions; built service
+  helpers to seed defaults and serialize ledger data; rewrote the banking routes to persist transfers
+  and expose JSON endpoints; implemented the settings template and form handlers; modernized the
+  banking JavaScript to sync with the API; and redesigned both base and banking styles for a 1200px
+  light layout.
+- **Why**: Persistent balances, fees, and interest rates are essential for reliable simulation play,
+  while administrators need an interface to tune banking behavior without touching code.
+- **Purpose**: Ensures every transaction and configuration change is tracked, empowers tuning through
+  a dedicated settings page, and presents the banking module in a readable light theme across devices.


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for bank settings, accounts, and transactions while seeding defaults
- rework banking routes, templates, and scripts to persist transfers, expose JSON endpoints, and provide a settings page
- refresh the global and banking styles for a 1200px light layout that remains responsive

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cfc07f1de08321b47f6c1561ac8d5b