### PR TITLE
Fix logging static asset blueprint

### DIFF
--- a/app/logging/__init__.py
+++ b/app/logging/__init__.py
@@ -5,6 +5,7 @@ bp = Blueprint(
     "logging",
     __name__,
     template_folder="templates",
+    static_folder="static",
 )
 
 from . import routes  # noqa: E402,F401

--- a/logs.md
+++ b/logs.md
@@ -1,5 +1,15 @@
 # Lifesim change log
 
+## 2025-09-21
+- **What**: Updated the logging blueprint to expose its static assets and verified the logs console
+  loads correctly.
+- **How**: Added the `static_folder="static"` argument when constructing the logging blueprint and
+  reloaded the Flask dev server to hit `/logs/` plus the stylesheet and script endpoints.
+- **Why**: Without the static folder registered, the console page raised `BuildError` exceptions
+  when resolving `/logs/static/...` assets, breaking its layout.
+- **Purpose**: Restores the dedicated logging console so users can review runtime activity with the
+  intended styles and interactivity.
+
 ## 2024-04-08
 - **What**: Established the foundational Flask application with modular blueprints for the home hub,
   banking, real estate, shop, and job systems. Added a shared base layout, responsive navigation, and


### PR DESCRIPTION
## Summary
- register the logging blueprint's static directory so its assets are routed under /logs/static
- document the fix in the project change log

## Testing
- `flask --app run:app --debug run`
- `curl -I http://127.0.0.1:5000/logs/`
- `curl -I http://127.0.0.1:5000/logs/static/styles/logs.css`
- `curl -I http://127.0.0.1:5000/logs/static/js/logs.js`


------
https://chatgpt.com/codex/tasks/task_e_68cfc4b2c8448321b37e43c5262f40a5