### PR TITLE
Add account guardrails and unified banking transfer flow

### DIFF
--- a/app/banking/models.py
+++ b/app/banking/models.py
@@ -14,10 +14,26 @@ class BankSettings(db.Model):
 
     id: int = db.Column(db.Integer, primary_key=True)
     bank_name: str = db.Column(db.String(120), nullable=False, default="Lifesim Bank")
-    standard_fee: Decimal = db.Column(db.Numeric(10, 2), nullable=False, default=Decimal("5.00"))
-    savings_interest_rate: Decimal = db.Column(
-        db.Numeric(5, 3), nullable=False, default=Decimal("2.100")
+    standard_fee: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("12.00")
     )
+    savings_interest_rate: Decimal = db.Column(
+        db.Numeric(5, 3), nullable=False, default=Decimal("2.000")
+    )
+    checking_minimum_balance: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("1500.00")
+    )
+    checking_minimum_fee: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("12.00")
+    )
+    checking_anchor_day: int = db.Column(db.Integer, nullable=False, default=25)
+    savings_minimum_balance: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("500.00")
+    )
+    savings_minimum_fee: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("5.00")
+    )
+    savings_anchor_day: int = db.Column(db.Integer, nullable=False, default=1)
     created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at: datetime = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/app/banking/static/js/banking_home.js
+++ b/app/banking/static/js/banking_home.js
@@ -1,0 +1,27 @@
+/* Additional behaviour for the banking home view. */
+document.addEventListener("DOMContentLoaded", () => {
+  const viewMoreTriggers = document.querySelectorAll("[data-view-more]");
+
+  viewMoreTriggers.forEach((trigger) => {
+    const targetUrl = trigger.getAttribute("data-view-more");
+    if (!targetUrl) {
+      return;
+    }
+
+    const navigate = () => {
+      window.location.href = targetUrl;
+    };
+
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      navigate();
+    });
+
+    trigger.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        navigate();
+      }
+    });
+  });
+});

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -60,8 +60,8 @@
 .banking-overview,
 .settings-panel {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 1.25rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 1.05rem;
   padding: clamp(1.5rem, 4vw, 2.5rem);
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -98,15 +98,15 @@
 .account-activity__grid {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2rem);
-  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
   align-items: start;
 }
 
 .account-activity__transactions,
 .account-activity__balances {
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: 1.1rem;
+  background: #ffffff;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.95rem;
   padding: clamp(1.25rem, 3vw, 1.75rem);
   display: grid;
   gap: clamp(1rem, 2vw, 1.5rem);
@@ -138,7 +138,7 @@
 }
 
 .transaction-list__item + .transaction-list__item {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid #dfe4ec;
 }
 
 .transaction-list__item:first-child {
@@ -191,6 +191,74 @@
   font-style: italic;
 }
 
+.transaction-view-more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.85rem;
+  padding: 0.5rem 1.4rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  width: fit-content;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.transaction-view-more:focus,
+.transaction-view-more:hover {
+  background: var(--accent-alt);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.transaction-view-more:focus-visible {
+  outline: 2px solid var(--accent-alt);
+  outline-offset: 2px;
+}
+
+.transaction-list--full {
+  max-height: none;
+}
+
+.pagination {
+  margin-top: 1.5rem;
+}
+
+.pagination ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+}
+
+.pagination a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.pagination a:hover,
+.pagination a:focus {
+  color: var(--accent-alt);
+}
+
+.pagination span[aria-disabled="true"] {
+  color: var(--muted);
+  cursor: default;
+}
+
+.pagination__info {
+  color: var(--muted);
+  font-weight: 600;
+}
+
 @media (max-width: 980px) {
   .account-activity__grid {
     grid-template-columns: 1fr;
@@ -205,8 +273,8 @@
 
 .account-card {
   background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.65rem;
   padding: clamp(1.1rem, 2.6vw, 1.5rem);
   display: grid;
   gap: 0.65rem;
@@ -262,9 +330,9 @@
 }
 
 .transfer-card {
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
+  background: #ffffff;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.85rem;
   padding: clamp(1.25rem, 3vw, 1.75rem);
   display: grid;
   gap: 1rem;
@@ -286,6 +354,93 @@
   gap: 1rem;
 }
 
+.transfer-card--wide {
+  grid-column: 1 / -1;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form-grid label span {
+  color: var(--text);
+}
+
+.form-grid__amount {
+  align-self: end;
+}
+
+.transfer-summary {
+  border: 1px solid #dfe4ec;
+  border-radius: 0.65rem;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  color: var(--muted);
+  line-height: 1.5;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.transfer-summary[data-state="warning"] {
+  background: rgba(185, 28, 28, 0.08);
+  border-color: rgba(185, 28, 28, 0.25);
+  color: var(--error);
+}
+
+.transfer-summary[data-state="ready"] {
+  background: rgba(21, 128, 61, 0.08);
+  border-color: rgba(21, 128, 61, 0.2);
+  color: var(--success);
+}
+
+.transfer-guidelines {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transfer-guidelines[data-state="idle"] {
+  display: none;
+}
+
+.transfer-guideline {
+  border-left: 3px solid #dfe4ec;
+  padding-left: 0.75rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.transfer-requirements {
+  border-top: 1px solid #dfe4ec;
+  padding-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transfer-requirements h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.transfer-requirements ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+}
+
+.transfer-requirements strong {
+  color: var(--text);
+}
+
 .form-row {
   display: grid;
   gap: 0.4rem;
@@ -300,8 +455,8 @@
 .transfer-form select,
 .settings-form input,
 .settings-account-form input {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.65rem;
   padding: 0.6rem 0.75rem;
   font: inherit;
   color: var(--text);
@@ -394,8 +549,8 @@
 
 .insight-card {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.85rem;
   padding: clamp(1rem, 2.5vw, 1.5rem);
   display: grid;
   gap: 0.85rem;
@@ -442,8 +597,8 @@
   display: grid;
   gap: 0.75rem;
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 1.25rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 1.05rem;
   padding: clamp(1.5rem, 4vw, 2.25rem);
 }
 
@@ -464,7 +619,7 @@
 }
 
 .settings-alert {
-  border-radius: 1rem;
+  border-radius: 0.85rem;
   padding: 0.85rem 1.1rem;
   border: 1px solid transparent;
   font-weight: 600;
@@ -521,8 +676,8 @@
 
 .settings-account-card {
   background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: 1rem;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.85rem;
   padding: clamp(1.25rem, 3vw, 1.75rem);
   display: grid;
   gap: 1rem;

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -4,6 +4,10 @@
   <link rel="stylesheet" href="{{ url_for('banking.static', filename='styles/banking.css') }}" />
 {% endblock %}
 
+{% block extra_js %}
+  <script src="{{ url_for('banking.static', filename='js/banking_home.js') }}" defer></script>
+{% endblock %}
+
 {% block content %}
   <div class="banking-shell">
     <section class="banking-subnav" aria-label="Banking navigation">
@@ -67,6 +71,16 @@
                   </li>
                 {% endfor %}
               </ul>
+              {% if has_more_transactions %}
+                <span
+                  class="transaction-view-more"
+                  role="link"
+                  tabindex="0"
+                  data-view-more="{{ url_for('banking.transactions') }}"
+                >
+                  View more
+                </span>
+              {% endif %}
             {% else %}
               <p class="transaction-list__empty">
                 No transactions recorded yet. Transfers will appear here automatically.

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -104,6 +104,62 @@
               <span class="suffix">%</span>
             </div>
           </label>
+          <label>
+            <span>Checking minimum balance</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="checking_minimum_balance"
+                value="{{ '%.2f'|format(bank_settings.checking_minimum_balance) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
+            <span>Checking fee when below minimum</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="checking_minimum_fee"
+                value="{{ '%.2f'|format(bank_settings.checking_minimum_fee) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
+            <span>Savings minimum balance</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="savings_minimum_balance"
+                value="{{ '%.2f'|format(bank_settings.savings_minimum_balance) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
+            <span>Savings fee when below minimum</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="savings_minimum_fee"
+                value="{{ '%.2f'|format(bank_settings.savings_minimum_fee) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
         </div>
         <button type="submit" class="settings-submit">Save bank settings</button>
       </form>

--- a/app/banking/templates/banking/transactions.html
+++ b/app/banking/templates/banking/transactions.html
@@ -1,0 +1,99 @@
+{% extends "layouts/base.html" %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{{ url_for('banking.static', filename='styles/banking.css') }}" />
+{% endblock %}
+
+{% block content %}
+  <div class="banking-shell">
+    <section class="banking-subnav" aria-label="Banking navigation">
+      <nav class="banking-tabs">
+        <a
+          href="{{ url_for('banking.home') }}"
+          class="banking-tab{% if active_banking_tab == 'home' %} is-active{% endif %}"
+          {% if active_banking_tab == 'home' %}aria-current="page"{% endif %}
+        >
+          Banking Home
+        </a>
+        <a
+          href="{{ url_for('banking.insights') }}"
+          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+        >
+          Account Insights
+        </a>
+        <a
+          href="{{ url_for('banking.transfer') }}"
+          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+        >
+          Banking Transfer
+        </a>
+        <a
+          href="{{ url_for('banking.settings') }}"
+          class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
+          {% if active_banking_tab == 'settings' %}aria-current="page"{% endif %}
+        >
+          Banking Settings
+        </a>
+      </nav>
+    </section>
+
+    <section class="banking-overview" aria-label="Banking transactions">
+      <header class="banking-overview__header">
+        <h1>Lifesim — Banking Transactions</h1>
+        <p>
+          Review every recorded credit and debit for {{ bank_settings.bank_name }}. Cash movements remain manual so the ledger
+          focuses on checking and savings accuracy.
+        </p>
+      </header>
+      <div class="account-activity__transactions" aria-label="Transaction ledger">
+        <h3>Transaction history</h3>
+        <p class="account-activity__description">
+          Showing
+          {% if pagination.total %}
+            {{ display_start }}–{{ display_end }} of {{ pagination.total }}
+          {% else %}
+            0
+          {% endif %}
+          transactions ordered from newest to oldest.
+        </p>
+        {% if transactions %}
+          <ul class="transaction-list transaction-list--full">
+            {% for transaction in transactions %}
+              <li class="transaction-list__item" data-direction="{{ transaction.direction }}">
+                <div class="transaction-list__row">
+                  <span class="transaction-list__name">{{ transaction.name }}</span>
+                  <span class="transaction-list__amount">{{ transaction.amount_display }}</span>
+                </div>
+                <p class="transaction-list__meta">{{ transaction.account_name }} · {{ transaction.timestamp }}</p>
+                <p class="transaction-list__description">{{ transaction.description }}</p>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="transaction-list__empty">No ledger entries yet. Submit transfers to populate the history.</p>
+        {% endif %}
+        <nav class="pagination" aria-label="Ledger pagination">
+          <ul>
+            <li>
+              {% if pagination.has_prev %}
+                <a href="{{ url_for('banking.transactions', page=pagination.prev_page, per_page=pagination.per_page) }}">Previous</a>
+              {% else %}
+                <span aria-disabled="true">Previous</span>
+              {% endif %}
+            </li>
+            <li class="pagination__info">Page {{ pagination.page }} of {{ pagination.pages }}</li>
+            <li>
+              {% if pagination.has_next %}
+                <a href="{{ url_for('banking.transactions', page=pagination.next_page, per_page=pagination.per_page) }}">Next</a>
+              {% else %}
+                <span aria-disabled="true">Next</span>
+              {% endif %}
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -71,67 +71,82 @@
         </div>
       </div>
       <div class="transfer-panel" aria-label="Manage cash movement">
-        <article class="transfer-card">
-          <h2>Move cash into accounts</h2>
-          <p>Shift money from your wallet into checking or savings. The ledger records the destination.</p>
+        <article class="transfer-card transfer-card--wide">
+          <h2>Transfer funds</h2>
+          <p>Move money between any two accounts. The system enforces minimum balances and records the ledger entries for checking and savings.</p>
           <form
-            id="form-hand-to-account"
+            id="form-account-transfer"
             class="transfer-form"
-            data-endpoint="{{ url_for('banking.api_deposit') }}"
+            data-endpoint="{{ url_for('banking.api_move') }}"
           >
-            <div class="form-row">
-              <label for="hand-transfer-amount">Amount</label>
-              <input
-                id="hand-transfer-amount"
-                name="amount"
-                type="number"
-                min="0.01"
-                step="0.01"
-                required
-              />
+            <div class="form-grid">
+              <label for="account-transfer-source">
+                <span>Source account</span>
+                <select
+                  id="account-transfer-source"
+                  name="source"
+                  required
+                  data-transfer-source
+                >
+                  <option value="" disabled selected>Select a source</option>
+                  {% for account in accounts %}
+                    <option value="{{ account.id }}">{{ account.name }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label for="account-transfer-destination">
+                <span>Destination account</span>
+                <select
+                  id="account-transfer-destination"
+                  name="destination"
+                  required
+                  data-transfer-destination
+                >
+                  <option value="" disabled selected>Select a destination</option>
+                  {% for account in accounts %}
+                    <option value="{{ account.id }}">{{ account.name }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+              <label for="account-transfer-amount" class="form-grid__amount">
+                <span>Amount</span>
+                <input
+                  id="account-transfer-amount"
+                  name="amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  required
+                />
+              </label>
             </div>
-            <div class="form-row">
-              <label for="hand-transfer-destination">Destination</label>
-              <select id="hand-transfer-destination" name="destination" required>
-                <option value="" disabled selected>Select an account</option>
-                <option value="checking">Checking</option>
-                <option value="savings">Savings</option>
-              </select>
+            <div class="transfer-summary" data-transfer-summary data-state="info">
+              Select a source and destination to preview the transfer narrative and guardrails.
             </div>
-            <button type="submit" class="transfer-button">Deposit into account</button>
+            <div class="transfer-guidelines" data-transfer-guidelines data-state="idle">
+              <div class="transfer-guideline" data-guideline="source" hidden></div>
+              <div class="transfer-guideline" data-guideline="destination" hidden></div>
+            </div>
+            <button type="submit" class="transfer-button">Submit transfer</button>
             <p class="form-feedback" data-feedback hidden></p>
           </form>
-        </article>
-        <article class="transfer-card">
-          <h2>Replenish cash</h2>
-          <p>Move funds out of checking or savings to keep spending money within reach.</p>
-          <form
-            id="form-account-to-hand"
-            class="transfer-form"
-            data-endpoint="{{ url_for('banking.api_withdraw') }}"
-          >
-            <div class="form-row">
-              <label for="account-withdraw-amount">Amount</label>
-              <input
-                id="account-withdraw-amount"
-                name="amount"
-                type="number"
-                min="0.01"
-                step="0.01"
-                required
-              />
-            </div>
-            <div class="form-row">
-              <label for="account-withdraw-source">Source</label>
-              <select id="account-withdraw-source" name="source" required>
-                <option value="" disabled selected>Select an account</option>
-                <option value="checking">Checking</option>
-                <option value="savings">Savings</option>
-              </select>
-            </div>
-            <button type="submit" class="transfer-button">Move funds to cash</button>
-            <p class="form-feedback" data-feedback hidden></p>
-          </form>
+          <section class="transfer-requirements" aria-label="Account requirements">
+            <h3>Minimum balance guardrails</h3>
+            <ul>
+              <li>
+                <strong>Checking:</strong>
+                Keep {{ '${:,.2f}'.format(bank_settings.checking_minimum_balance) }} on hand or a
+                {{ '${:,.2f}'.format(bank_settings.checking_minimum_fee) }} fee posts on the
+                anchor date.
+              </li>
+              <li>
+                <strong>Savings:</strong>
+                Hold {{ '${:,.2f}'.format(bank_settings.savings_minimum_balance) }} to avoid a
+                {{ '${:,.2f}'.format(bank_settings.savings_minimum_fee) }} maintenance charge when
+                interest credits.
+              </li>
+            </ul>
+          </section>
         </article>
       </div>
     </section>

--- a/logs.md
+++ b/logs.md
@@ -1,5 +1,15 @@
 # Lifesim change log
-
+## 2025-09-25
+- **What**: Rebuilt banking transfers into a unified source-to-destination flow, added a full ledger view, refreshed account
+  insights with anchor date calculations, and tightened the dashboard styling.
+- **How**: Introduced a general `/api/transfer/move` endpoint with reusable balance update helpers, created a paginated
+  `/banking/transactions` route and template, expanded settings to capture per-account minimums and fees, enhanced interest
+  insight logic to project next payouts, and retuned the home/transfer UI plus CSS to emphasise ledger actions without cash
+  noise.
+- **Why**: Players needed a single transfer form that respects account guardrails, clearer visibility into upcoming charges
+  and interest credits, and a way to audit more than four transactions without cash cluttering the history.
+- **Purpose**: Keeps cash management intuitive, highlights policy-driven anchor dates, and makes it easier to review and
+  configure banking behaviour while maintaining accessible styling.
 ## 2025-09-24
 - **What**: Simplified the banking dashboard language, resized account tiles, and hardened transfer commits.
 - **How**: Replaced canned descriptions on the home and transfer templates, tightened typography in the


### PR DESCRIPTION
## Summary
- add a unified account-to-account transfer endpoint and UI with guardrail messaging
- extend banking settings and insights to cover anchor dates, projected interest, and per-account minimum fees
- introduce a paginated transactions page, update the home dashboard styling, and document the change in logs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd5d1d33483218633bff2751cc7c7