### PR TITLE
Implement account onboarding and refresh banking insights

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,10 +43,21 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     @app.context_processor
     def inject_globals() -> dict[str, object]:
         """Inject shared template variables."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        from .banking.services import get_bank_settings
+
+        try:
+            settings = get_bank_settings()
+        except SQLAlchemyError:
+            settings = None
+        bank_name = settings.bank_name if settings else "Lifesim Bank"
         return {
             "environment": app.config.get("ENVIRONMENT", "development"),
             "log_levels": log_manager.available_levels,
             "log_components": log_manager.available_components,
+            "bank_brand_name": bank_name,
+            "global_bank_settings": settings,
         }
 
     return app

--- a/app/banking/models.py
+++ b/app/banking/models.py
@@ -34,6 +34,12 @@ class BankSettings(db.Model):
         db.Numeric(10, 2), nullable=False, default=Decimal("5.00")
     )
     savings_anchor_day: int = db.Column(db.Integer, nullable=False, default=1)
+    checking_opening_deposit: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("100.00")
+    )
+    savings_opening_deposit: Decimal = db.Column(
+        db.Numeric(10, 2), nullable=False, default=Decimal("50.00")
+    )
     created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at: datetime = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -123,6 +123,12 @@
   line-height: 1.55;
 }
 
+.account-activity__empty {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
 .transaction-list {
   list-style: none;
   margin: 0;
@@ -305,6 +311,232 @@
   margin: 0;
   font-size: clamp(1.45rem, 2.6vw, 1.9rem);
   font-variant-numeric: tabular-nums;
+}
+
+.account-due {
+  margin-top: clamp(1.5rem, 3vw, 2rem);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.account-due h4 {
+  margin: 0;
+}
+
+.account-due__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.account-due__card {
+  border: 1px solid #dfe4ec;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: #f9fbff;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.account-due__card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.account-due__card h5 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.account-due__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.account-due__amount {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.account-due__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.insights-layout {
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.insight-panel {
+  background: #ffffff;
+  border: 1px solid #dfe4ec;
+  border-radius: 1rem;
+  padding: clamp(1.5rem, 3.5vw, 2.25rem);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.insight-panel__header h2 {
+  margin: 0 0 0.5rem;
+}
+
+.insight-panel__header p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.insight-panel__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.insight-summary {
+  border: 1px solid #e4e9f1;
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  background: #f8fafc;
+}
+
+.insight-summary__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.insight-summary__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.insight-status {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.insight-status--open {
+  background: rgba(21, 128, 61, 0.12);
+  color: var(--success);
+}
+
+.insight-status--closed {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--error);
+}
+
+.insight-summary__details {
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.insight-summary__details div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.insight-summary__details dt {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.insight-summary__details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.insight-apy {
+  display: grid;
+  gap: 0.75rem;
+  background: #f1f7ff;
+  border: 1px solid #d6e4fb;
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+}
+
+.insight-apy__headline {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.insight-apy__note {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.insight-due-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.insight-due-card {
+  border: 1px solid #e4e9f1;
+  border-radius: 0.85rem;
+  padding: 1.1rem;
+  background: #f8fafc;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.insight-due-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.insight-due-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.insight-due-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.insight-due-amount {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.insight-due-date {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.insight-due-tip {
+  margin: 0;
+  line-height: 1.55;
+  color: var(--muted);
 }
 
 .transfer-balances {

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -90,6 +90,11 @@
           <div class="account-activity__balances" aria-label="Account balances">
             <h3>Account balances</h3>
             <p class="account-activity__description">Track the latest totals for each account.</p>
+            {% if not has_open_accounts %}
+              <p class="account-activity__empty">
+                No banking accounts are open yet. Use the Open Account action on the home page to get started.
+              </p>
+            {% endif %}
             <div class="account-grid">
               {% for account in accounts %}
                 <article class="account-card" data-account-card data-account="{{ account.id }}">
@@ -105,6 +110,21 @@
                 </article>
               {% endfor %}
             </div>
+            <section class="account-due" aria-label="Account due summary">
+              <h4>Account Due</h4>
+              <div class="account-due__grid">
+                {% for due in account_due_cards %}
+                  <article class="account-due__card">
+                    <header>
+                      <h5>{{ due.name }}</h5>
+                      <span class="account-due__label">Amount Due</span>
+                    </header>
+                    <p class="account-due__amount">{{ due.amount }}</p>
+                    <p class="account-due__note">{{ due.due_date }}</p>
+                  </article>
+                {% endfor %}
+              </div>
+            </section>
           </div>
         </div>
       </section>

--- a/app/banking/templates/banking/insights.html
+++ b/app/banking/templates/banking/insights.html
@@ -47,35 +47,91 @@
           each transfer with confidence.
         </p>
       </header>
-      <div class="banking-insights">
-        <header>
-          <h2>Account insights and fees</h2>
-          <p>
-            Study the policies for each account before moving money. Staying ahead of fees protects your
-            long-term savings.
-          </p>
-        </header>
-        <div class="insight-grid">
-          {% for insight in account_insights %}
-            <article class="insight-card">
-              <h3>{{ insight.account }}</h3>
-              <ul class="insight-list">
-                {% for detail in insight.details %}
-                  <li class="insight-item">
-                    <span class="insight-label">{{ detail.label }}</span>
-                    <span class="insight-value">{{ detail.value }}</span>
-                  </li>
-                {% endfor %}
-              </ul>
-            </article>
-          {% endfor %}
-        </div>
-        <footer class="insight-footer">
-          <p>
-            Monitor balances weekly and rebalance through the transfer hub ahead of billing cycles. Captured
-            transactions double as an audit trail for every move.
-          </p>
-        </footer>
+      <div class="insights-layout">
+        <section class="insight-panel" aria-label="Anchor dates">
+          <header class="insight-panel__header">
+            <h2>Anchor timelines</h2>
+            <p>See when each account started, when reviews occur, and what balances keep fees away.</p>
+          </header>
+          <div class="insight-panel__grid">
+            {% for key in ("checking", "savings") %}
+              {% set insight = account_insights[key] %}
+              <article class="insight-summary">
+                <header class="insight-summary__header">
+                  <h3>{{ insight.name }}</h3>
+                  <span class="insight-status{% if insight.is_open %} insight-status--open{% else %} insight-status--closed{% endif %}">
+                    {% if insight.is_open %}Open{% else %}Not open{% endif %}
+                  </span>
+                </header>
+                <dl class="insight-summary__details">
+                  <div>
+                    <dt>Account opened</dt>
+                    <dd>{% if insight.is_open %}{{ insight.opened }}{% else %}Pending account opening{% endif %}</dd>
+                  </div>
+                  <div>
+                    <dt>Next anchor date</dt>
+                    <dd>{{ insight.next_anchor }}</dd>
+                  </div>
+                  <div>
+                    <dt>Minimum balance</dt>
+                    <dd>{{ insight.minimum_balance }}</dd>
+                  </div>
+                  <div>
+                    <dt>Fee if below</dt>
+                    <dd>{{ insight.fee }}</dd>
+                  </div>
+                </dl>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+
+        <section class="insight-panel" aria-label="Savings interest outlook">
+          <header class="insight-panel__header">
+            <h2>Interest outlook</h2>
+            <p>
+              Understand how {{ account_insights.savings.apy_rate }} grows your savings and when the next payout is expected.
+            </p>
+          </header>
+          <div class="insight-apy">
+            {% if account_insights.savings.is_open %}
+              <p class="insight-apy__headline">
+                Maintain the current balance to earn <strong>{{ account_insights.savings.projected_interest }}</strong>
+                on {{ account_insights.savings.next_anchor }}.
+              </p>
+              <p class="insight-apy__note">
+                Interest posts on the anchor date and compounds automatically. Deposits before that day increase the payout.
+              </p>
+            {% else %}
+              <p class="insight-apy__headline">
+                Open the savings account to start compounding at {{ account_insights.savings.apy_rate }}.
+              </p>
+              <p class="insight-apy__note">
+                Meeting the opening deposit unlocks the interest schedule and begins tracking growth immediately.
+              </p>
+            {% endif %}
+          </div>
+        </section>
+
+        <section class="insight-panel" aria-label="Due date guidance">
+          <header class="insight-panel__header">
+            <h2>Due date guidance</h2>
+            <p>Review how to avoid service charges and keep each account compliant ahead of the anchor date.</p>
+          </header>
+          <div class="insight-due-grid">
+            {% for due in account_insights.due_items %}
+              <article class="insight-due-card">
+                <header>
+                  <h3>{{ due.name }}</h3>
+                  <span class="insight-due-label">Amount Due</span>
+                </header>
+                <p class="insight-due-amount">{{ due.amount }}</p>
+                <p class="insight-due-date">{{ due.due_date }}</p>
+                <p class="insight-due-tip">{{ due.tip }}</p>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
       </div>
     </section>
   </div>

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -133,6 +133,20 @@
             </div>
           </label>
           <label>
+            <span>Checking opening deposit required</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="checking_opening_deposit"
+                value="{{ '%.2f'|format(bank_settings.checking_opening_deposit) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
             <span>Savings minimum balance</span>
             <div class="settings-input">
               <span class="prefix">$</span>
@@ -154,6 +168,20 @@
                 type="number"
                 name="savings_minimum_fee"
                 value="{{ '%.2f'|format(bank_settings.savings_minimum_fee) }}"
+                min="0"
+                step="0.01"
+                required
+              />
+            </div>
+          </label>
+          <label>
+            <span>Savings opening deposit required</span>
+            <div class="settings-input">
+              <span class="prefix">$</span>
+              <input
+                type="number"
+                name="savings_opening_deposit"
+                value="{{ '%.2f'|format(bank_settings.savings_opening_deposit) }}"
                 min="0"
                 step="0.01"
                 required

--- a/app/index/routes.py
+++ b/app/index/routes.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 from flask import render_template
 
+from ..banking.services import (
+    decimal_to_number,
+    ensure_bank_defaults,
+    fetch_accounts,
+    format_currency,
+    get_bank_settings,
+)
 from ..logging_service import log_manager
 from . import bp
 
@@ -10,6 +17,18 @@ from . import bp
 @bp.route("/")
 def home():
     """Render the main dashboard hub."""
+    ensure_bank_defaults()
+    settings = get_bank_settings()
+    accounts = fetch_accounts()
+
+    cash_account = next((account for account in accounts if account.slug == "hand"), None)
+    cash_balance = cash_account.balance if cash_account else 0
+    available_cash = format_currency(cash_balance)
+    available_cash_value = decimal_to_number(cash_balance)
+    account_slugs = {account.slug for account in accounts if account.slug != "hand"}
+    missing_accounts = [slug for slug in ("checking", "savings") if slug not in account_slugs]
+    has_any_accounts = bool(account_slugs)
+
     log_manager.record(
         component="Home",
         action="view",
@@ -29,5 +48,18 @@ def home():
         "index/home.html",
         title="Lifesim — Home",
         metrics=quick_metrics,
+        bank_settings=settings,
+        available_cash=available_cash,
+        available_cash_value=available_cash_value,
+        has_bank_accounts=has_any_accounts,
+        missing_accounts=missing_accounts,
+        account_opening_requirements={
+            "checking": format_currency(settings.checking_opening_deposit),
+            "savings": format_currency(settings.savings_opening_deposit),
+        },
+        account_opening_requirements_value={
+            "checking": decimal_to_number(settings.checking_opening_deposit),
+            "savings": decimal_to_number(settings.savings_opening_deposit),
+        },
         active_nav="home",
     )

--- a/app/index/static/js/home.js
+++ b/app/index/static/js/home.js
@@ -2,6 +2,245 @@
 document.addEventListener("DOMContentLoaded", () => {
   const metrics = document.querySelectorAll(".metric");
   const timelineItems = document.querySelectorAll(".timeline__list li");
+  const openAccountButton = document.querySelector("[data-open-account]");
+  const modal = document.getElementById("account-opening-modal");
+  const modalBackdrop = document.querySelector("[data-modal-backdrop]");
+  const modalForm = document.getElementById("account-opening-form");
+  const modalFeedback = document.querySelector("[data-modal-feedback]");
+  const closeModalButtons = document.querySelectorAll("[data-close-modal]");
+  const submitButton = document.querySelector("[data-submit-button]");
+  const configElement = document.getElementById("account-opening-config");
+  const accountOptions = document.querySelectorAll("[data-account-option]");
+  const depositSections = document.querySelectorAll("[data-deposit-section]");
+
+  const defaultConfig = { available_cash: 0, requirements: {}, endpoint: "" };
+  let openingConfig = defaultConfig;
+
+  if (configElement) {
+    try {
+      const raw = configElement.textContent?.trim() || "";
+      openingConfig = raw ? JSON.parse(raw) : defaultConfig;
+    } catch (error) {
+      openingConfig = defaultConfig;
+      console.error("Failed to parse account opening config", error);
+    }
+  }
+
+  const formatCurrency = (value) => {
+    const number = Number.parseFloat(value);
+    const safe = Number.isFinite(number) ? number : 0;
+    return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(safe);
+  };
+
+  const showModal = () => {
+    if (!modal || !modalBackdrop) {
+      return;
+    }
+    modal.hidden = false;
+    modalBackdrop.hidden = false;
+    modal.setAttribute("aria-hidden", "false");
+    const focusTarget = modal.querySelector("[data-account-option]") || modal;
+    focusTarget.focus();
+  };
+
+  const hideModal = () => {
+    if (!modal || !modalBackdrop) {
+      return;
+    }
+    modal.hidden = true;
+    modalBackdrop.hidden = true;
+    modal.setAttribute("aria-hidden", "true");
+    if (modalForm) {
+      modalForm.reset();
+    }
+    depositSections.forEach((section) => {
+      section.hidden = true;
+      const input = section.querySelector("input");
+      if (input) {
+        input.value = "";
+      }
+    });
+    if (modalFeedback) {
+      modalFeedback.hidden = true;
+      modalFeedback.textContent = "";
+      modalFeedback.dataset.state = "";
+    }
+  };
+
+  const toggleDepositSection = (checkbox) => {
+    if (!checkbox) return;
+    const account = checkbox.value;
+    const section = modal?.querySelector(`[data-deposit-section="${account}"]`);
+    const input = modal?.querySelector(`[data-deposit-input="${account}"]`);
+    if (!section || !input) {
+      return;
+    }
+    if (checkbox.checked) {
+      const minimum = openingConfig.requirements?.[account] ?? 0;
+      section.hidden = false;
+      input.value = minimum ? minimum.toFixed(2) : "";
+      input.min = minimum ? minimum.toFixed(2) : "0";
+      input.focus();
+    } else {
+      section.hidden = true;
+      input.value = "";
+    }
+  };
+
+  const hideFeedback = () => {
+    if (!modalFeedback) return;
+    modalFeedback.hidden = true;
+    modalFeedback.textContent = "";
+    modalFeedback.dataset.state = "";
+  };
+
+  const displayFeedback = (message, state = "error") => {
+    if (!modalFeedback) return;
+    modalFeedback.textContent = message;
+    modalFeedback.dataset.state = state;
+    modalFeedback.hidden = false;
+  };
+
+  const collectSelections = () => {
+    const selections = {};
+    accountOptions.forEach((option) => {
+      if (!option.checked) {
+        return;
+      }
+      const account = option.value;
+      const input = modal?.querySelector(`[data-deposit-input="${account}"]`);
+      if (!input) {
+        return;
+      }
+      const value = Number.parseFloat(input.value);
+      selections[account] = Number.isFinite(value) ? value : NaN;
+    });
+    return selections;
+  };
+
+  const validateSelections = (selections) => {
+    const errors = [];
+    const requirements = openingConfig.requirements || {};
+    let total = 0;
+
+    Object.entries(selections).forEach(([account, amount]) => {
+      if (!Number.isFinite(amount) || amount <= 0) {
+        errors.push(`Enter a valid deposit for the ${account} account.`);
+        return;
+      }
+      const minimum = requirements?.[account] ?? 0;
+      if (amount < minimum) {
+        errors.push(
+          `Deposit at least ${formatCurrency(minimum)} for the ${account} account.`
+        );
+      }
+      total += amount;
+    });
+
+    if (!Object.keys(selections).length) {
+      errors.push("Select at least one account to open.");
+    }
+
+    if (total > (openingConfig.available_cash ?? 0)) {
+      errors.push(
+        `Cash only has ${formatCurrency(openingConfig.available_cash)} available. Reduce the deposits.`
+      );
+    }
+
+    return errors;
+  };
+
+  const submitForm = async (event) => {
+    event.preventDefault();
+    if (!modalForm || !submitButton) {
+      return;
+    }
+
+    hideFeedback();
+    const selections = collectSelections();
+    const errors = validateSelections(selections);
+
+    if (errors.length) {
+      displayFeedback(errors.join(" "), "error");
+      return;
+    }
+
+    submitButton.disabled = true;
+    submitButton.textContent = "Opening...";
+
+    try {
+      const response = await fetch(openingConfig.endpoint || "/banking/api/accounts/open", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ accounts: Object.fromEntries(
+          Object.entries(selections).map(([account, amount]) => [account, { deposit: amount }])
+        ) }),
+      });
+
+      const payload = await response.json();
+
+      if (!response.ok || !payload.success) {
+        const message = payload?.message || "Unable to open accounts right now.";
+        displayFeedback(message, "error");
+        return;
+      }
+
+      displayFeedback(payload.message || "Accounts opened successfully.", "success");
+      setTimeout(() => {
+        window.location.reload();
+      }, 1200);
+    } catch (error) {
+      console.error("Failed to open accounts", error);
+      displayFeedback("A network error occurred. Please try again shortly.", "error");
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = "Open Selected Accounts";
+    }
+  };
+
+  if (openAccountButton) {
+    openAccountButton.addEventListener("click", () => {
+      depositSections.forEach((section) => {
+        section.hidden = true;
+        const input = section.querySelector("input");
+        if (input) {
+          input.value = "";
+        }
+      });
+      showModal();
+    });
+  }
+
+  closeModalButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      hideModal();
+      if (openAccountButton) {
+        openAccountButton.focus();
+      }
+    });
+  });
+
+  if (modalBackdrop) {
+    modalBackdrop.addEventListener("click", hideModal);
+  }
+
+  accountOptions.forEach((option) => {
+    option.addEventListener("change", () => toggleDepositSection(option));
+  });
+
+  if (modalForm) {
+    modalForm.addEventListener("submit", submitForm);
+    modalForm.addEventListener("input", hideFeedback);
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal && !modal.hidden) {
+      hideModal();
+      if (openAccountButton) {
+        openAccountButton.focus();
+      }
+    }
+  });
 
   metrics.forEach((metric) => {
     metric.setAttribute("tabindex", "0");

--- a/app/index/static/styles/home.css
+++ b/app/index/static/styles/home.css
@@ -124,3 +124,191 @@
   border-left-color: var(--accent);
   color: var(--accent);
 }
+
+.bank-onboarding {
+  margin: clamp(1.5rem, 4vw, 2.5rem) 0;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(15, 23, 42, 0.85));
+  display: grid;
+  gap: 1.25rem;
+  align-items: center;
+  color: #f8fafc;
+}
+
+.bank-onboarding__copy h2 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.75rem, 3vw, 2.2rem);
+}
+
+.bank-onboarding__copy p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.bank-onboarding__actions {
+  display: flex;
+  align-items: center;
+}
+
+.bank-onboarding__footnote {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.modal[hidden],
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.modal__dialog {
+  width: min(90%, 520px);
+  background: #ffffff;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+  color: var(--text);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 1rem;
+}
+
+.modal__header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal__form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.modal__intro {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.modal__fieldset {
+  border: 1px solid #dfe4ec;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.modal__fieldset legend {
+  padding: 0 0.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.modal__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.modal__option input {
+  margin-top: 0.25rem;
+}
+
+.modal__option-label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.modal__option-note {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.modal__deposit {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.modal__deposit label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.modal__input {
+  display: flex;
+  align-items: center;
+  border: 1px solid #dfe4ec;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  gap: 0.5rem;
+  background: #f8fafc;
+}
+
+.modal__input-prefix {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.modal__input input {
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.modal__feedback {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+}
+
+.modal__feedback[data-state="error"] {
+  background: rgba(185, 28, 28, 0.1);
+  color: var(--error);
+  border: 1px solid rgba(185, 28, 28, 0.2);
+}
+
+.modal__feedback[data-state="success"] {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--success);
+  border: 1px solid rgba(21, 128, 61, 0.2);
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  z-index: 999;
+}

--- a/app/index/templates/index/home.html
+++ b/app/index/templates/index/home.html
@@ -24,6 +24,31 @@
     </div>
   </section>
 
+  {% if missing_accounts %}
+    {% set missing_titles = missing_accounts | map('capitalize') | list %}
+    {% set missing_phrase = missing_titles | join(' and ') %}
+    <section class="bank-onboarding" aria-label="Bank account onboarding">
+      <div class="bank-onboarding__copy">
+        {% if not has_bank_accounts %}
+          <h2>Welcome to {{ bank_settings.bank_name }}</h2>
+          <p>
+            Open your first checking or savings account to move beyond cash. You have {{ available_cash }} ready to
+            allocate.
+          </p>
+        {% else %}
+          <h2>{{ bank_settings.bank_name }} account options</h2>
+          <p>
+            Your {{ missing_phrase }} account is still closed. Move funds from cash to unlock full banking features.
+          </p>
+        {% endif %}
+      </div>
+      <div class="bank-onboarding__actions">
+        <button type="button" class="cta" data-open-account>Open Account</button>
+      </div>
+      <p class="bank-onboarding__footnote">Minimum deposits — Checking: {{ account_opening_requirements.checking }}, Savings: {{ account_opening_requirements.savings }}</p>
+    </section>
+  {% endif %}
+
   <section class="metrics" aria-label="Quick metrics">
     {% for label, value in metrics.items() %}
       <article class="metric">
@@ -53,4 +78,79 @@
       </li>
     </ol>
   </section>
+
+  <div class="modal" id="account-opening-modal" role="dialog" aria-modal="true" aria-labelledby="account-opening-title" hidden>
+    <div class="modal__dialog">
+      <header class="modal__header">
+        <h2 id="account-opening-title">Open a banking account</h2>
+        <button type="button" class="modal__close" data-close-modal aria-label="Close">×</button>
+      </header>
+      <form id="account-opening-form" class="modal__form">
+        <p class="modal__intro">
+          Choose which accounts to open and decide how much to deposit from cash. You currently have {{ available_cash }} on hand.
+        </p>
+        <fieldset class="modal__fieldset">
+          <legend>Select account types</legend>
+          <label class="modal__option">
+            <input type="checkbox" value="checking" data-account-option {% if 'checking' not in missing_accounts %}disabled{% endif %} />
+            <span class="modal__option-label">
+              Checking Account
+              <span class="modal__option-note">
+                {% if 'checking' not in missing_accounts %}
+                  Already open
+                {% else %}
+                  Minimum deposit {{ account_opening_requirements.checking }}
+                {% endif %}
+              </span>
+            </span>
+          </label>
+          <div class="modal__deposit" data-deposit-section="checking" hidden>
+            <label>
+              <span>Deposit amount</span>
+              <div class="modal__input">
+                <span class="modal__input-prefix">$</span>
+                <input type="number" step="0.01" min="0" data-deposit-input="checking" />
+              </div>
+            </label>
+          </div>
+          <label class="modal__option">
+            <input type="checkbox" value="savings" data-account-option {% if 'savings' not in missing_accounts %}disabled{% endif %} />
+            <span class="modal__option-label">
+              Savings Account
+              <span class="modal__option-note">
+                {% if 'savings' not in missing_accounts %}
+                  Already open
+                {% else %}
+                  Minimum deposit {{ account_opening_requirements.savings }}
+                {% endif %}
+              </span>
+            </span>
+          </label>
+          <div class="modal__deposit" data-deposit-section="savings" hidden>
+            <label>
+              <span>Deposit amount</span>
+              <div class="modal__input">
+                <span class="modal__input-prefix">$</span>
+                <input type="number" step="0.01" min="0" data-deposit-input="savings" />
+              </div>
+            </label>
+          </div>
+        </fieldset>
+        <div class="modal__feedback" data-modal-feedback hidden></div>
+        <div class="modal__actions">
+          <button type="button" class="cta secondary" data-close-modal>Cancel</button>
+          <button type="submit" class="cta" data-submit-button>Open Selected Accounts</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="modal-backdrop" data-modal-backdrop hidden></div>
+
+  <script type="application/json" id="account-opening-config">
+    {{ {
+      "available_cash": available_cash_value,
+      "requirements": account_opening_requirements_value,
+      "endpoint": url_for('banking.api_open_accounts')
+    } | tojson }}
+  </script>
 {% endblock %}

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -11,7 +11,7 @@
   <body>
     <div class="layout">
       <header class="top-bar">
-        <div class="brand">Lifesim</div>
+        <div class="brand">{{ bank_brand_name }}</div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
           <span class="toggle-label">Menu</span>
         </button>

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,14 @@
 # Lifesim change log
+## 2025-09-26
+- **What**: Introduced an account opening workflow, revamped banking insights, added due summaries, and ensured the bank
+  name is consistent across the app.
+- **How**: Added a modal on the home page to open checking or savings accounts with configurable deposits, created a
+  `/banking/api/accounts/open` endpoint, recalculated account due data, refreshed the insights template with structured
+  panels, extended settings with opening deposit requirements, and surfaced the bank name through the base layout context.
+- **Why**: Players now begin with only cash and need guidance to create accounts, plus clearer insight cards and due-date
+  messaging make it easier to understand obligations and interest earnings.
+- **Purpose**: Provides a professional banking experience that mirrors onboarding flows, keeps account requirements
+  obvious, and maintains branding cohesion from navigation through detailed reports.
 ## 2025-09-25
 - **What**: Rebuilt banking transfers into a unified source-to-destination flow, added a full ledger view, refreshed account
   insights with anchor date calculations, and tightened the dashboard styling.


### PR DESCRIPTION
## Summary
- add a banking account opening workflow with modal UI, new API endpoint, and configurable opening deposit requirements
- refresh the banking home and insights views with account due summaries, structured anchor/interest panels, and consistent bank branding
- update banking settings, services, and context injection to support new defaults while logging the changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdfe5db50832199a387f8b9338567