### PR TITLE
Fix banking due calculations and polish banking UI

### DIFF
--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -99,7 +99,7 @@
   display: grid;
   gap: clamp(1.5rem, 3vw, 2rem);
   grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
-  align-items: start;
+  align-items: stretch;
 }
 
 .account-activity__transactions,
@@ -107,9 +107,11 @@
   background: #ffffff;
   border: 1px solid #dfe4ec;
   border-radius: 0.95rem;
-  padding: clamp(1.25rem, 3vw, 1.75rem);
-  display: grid;
-  gap: clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(1.1rem, 3vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.85rem, 2vw, 1.25rem);
+  height: 100%;
 }
 
 .account-activity__transactions h3,
@@ -273,17 +275,19 @@
 
 .account-grid {
   display: grid;
-  gap: clamp(1.25rem, 2.5vw, 1.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.1rem, 2.2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  flex: 1 1 auto;
+  align-content: start;
 }
 
 .account-card {
   background: var(--surface-alt);
   border: 1px solid #dfe4ec;
-  border-radius: 0.65rem;
-  padding: clamp(1.1rem, 2.6vw, 1.5rem);
+  border-radius: 0.6rem;
+  padding: clamp(0.9rem, 2.2vw, 1.25rem);
   display: grid;
-  gap: 0.65rem;
+  gap: 0.55rem;
 }
 
 .account-card header {
@@ -293,7 +297,7 @@
 
 .account-card header h2 {
   margin: 0;
-  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
   font-weight: 600;
   line-height: 1.3;
 }
@@ -309,12 +313,13 @@
 
 .account-card__balance {
   margin: 0;
-  font-size: clamp(1.45rem, 2.6vw, 1.9rem);
+  font-size: clamp(1.15rem, 2.2vw, 1.5rem);
   font-variant-numeric: tabular-nums;
 }
 
 .account-due {
-  margin-top: clamp(1.5rem, 3vw, 2rem);
+  margin-top: auto;
+  padding-top: clamp(1rem, 2vw, 1.5rem);
   display: grid;
   gap: 0.75rem;
 }
@@ -325,17 +330,18 @@
 
 .account-due__grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  align-content: start;
 }
 
 .account-due__card {
   border: 1px solid #dfe4ec;
-  border-radius: 0.75rem;
-  padding: 1rem 1.25rem;
+  border-radius: 0.65rem;
+  padding: 0.85rem 1rem;
   background: #f9fbff;
   display: grid;
-  gap: 0.45rem;
+  gap: 0.4rem;
 }
 
 .account-due__card header {
@@ -352,7 +358,7 @@
 }
 
 .account-due__label {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--muted);
@@ -360,7 +366,7 @@
 
 .account-due__amount {
   margin: 0;
-  font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
@@ -368,6 +374,13 @@
 .account-due__note {
   margin: 0;
   font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.account-due__tip {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
   color: var(--muted);
 }
 

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -60,7 +60,7 @@
                 Open your first checking or savings account with {{ available_cash }} ready in cash to allocate.
               </p>
             {% else %}
-              <h2>{{ bank_settings.bank_name }} account options</h2>
+              <h2>{{ bank_settings.bank_name }} Account Options</h2>
               <p>
                 Your {{ missing_phrase }} account is still closed. Move cash into the bank to unlock more tools.
               </p>
@@ -82,7 +82,7 @@
         </header>
         <div class="account-activity__grid">
           <div class="account-activity__transactions" aria-label="Recent transactions">
-            <h3>Recent transactions</h3>
+            <h3>Recent Transactions</h3>
             <p class="account-activity__description">
               The ledger captures deposits and withdrawals the moment they are submitted.
             </p>
@@ -116,7 +116,7 @@
             {% endif %}
           </div>
           <div class="account-activity__balances" aria-label="Account balances">
-            <h3>Account balances</h3>
+            <h3>Account Balances</h3>
             <p class="account-activity__description">Track the latest totals for each account.</p>
             {% if not has_open_accounts %}
               <p class="account-activity__empty">
@@ -149,6 +149,7 @@
                     </header>
                     <p class="account-due__amount">{{ due.amount }}</p>
                     <p class="account-due__note">{{ due.due_date }}</p>
+                    <p class="account-due__tip">{{ due.tip }}</p>
                   </article>
                 {% endfor %}
               </div>
@@ -161,7 +162,7 @@
     <div class="modal" id="account-opening-modal" role="dialog" aria-modal="true" aria-labelledby="account-opening-title" hidden>
       <div class="modal__dialog">
         <header class="modal__header">
-          <h2 id="account-opening-title">Open a banking account</h2>
+          <h2 id="account-opening-title">Open a Banking Account</h2>
           <button type="button" class="modal__close" data-close-modal aria-label="Close">×</button>
         </header>
         <form id="account-opening-form" class="modal__form">
@@ -169,7 +170,7 @@
             Choose which accounts to open and decide how much to deposit from cash. You currently have {{ available_cash }} on hand.
           </p>
           <fieldset class="modal__fieldset">
-            <legend>Select account types</legend>
+            <legend>Select Account Types</legend>
             <label class="modal__option">
               <input type="checkbox" value="checking" data-account-option {% if 'checking' not in missing_accounts %}disabled{% endif %} />
               <span class="modal__option-label">

--- a/app/banking/templates/banking/insights.html
+++ b/app/banking/templates/banking/insights.html
@@ -41,7 +41,7 @@
 
     <section class="banking-overview" aria-label="Account insights">
       <header class="banking-overview__header">
-        <h1>Lifesim — Banking Insights</h1>
+        <h1>{{ bank_settings.bank_name }} — Banking Insights</h1>
         <p>
           Understand the fees, interest, and cash guidance powering {{ bank_settings.bank_name }} so you can plan
           each transfer with confidence.
@@ -50,7 +50,7 @@
       <div class="insights-layout">
         <section class="insight-panel" aria-label="Anchor dates">
           <header class="insight-panel__header">
-            <h2>Anchor timelines</h2>
+            <h2>Anchor Timelines</h2>
             <p>See when each account started, when reviews occur, and what balances keep fees away.</p>
           </header>
           <div class="insight-panel__grid">
@@ -88,7 +88,7 @@
 
         <section class="insight-panel" aria-label="Savings interest outlook">
           <header class="insight-panel__header">
-            <h2>Interest outlook</h2>
+            <h2>Interest Outlook</h2>
             <p>
               Understand how {{ account_insights.savings.apy_rate }} grows your savings and when the next payout is expected.
             </p>
@@ -115,7 +115,7 @@
 
         <section class="insight-panel" aria-label="Due date guidance">
           <header class="insight-panel__header">
-            <h2>Due date guidance</h2>
+            <h2>Due Date Guidance</h2>
             <p>Review how to avoid service charges and keep each account compliant ahead of the anchor date.</p>
           </header>
           <div class="insight-due-grid">

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -41,7 +41,7 @@
 
     <section class="settings-intro">
       <header>
-        <h1>Lifesim — Banking Settings</h1>
+        <h1>{{ bank_settings.bank_name }} — Banking Settings</h1>
         <p>
           Configure {{ bank_settings.bank_name }} by defining fees, savings interest, and how much money sits in each
           account.
@@ -60,7 +60,7 @@
 
     <section class="settings-panel" aria-label="Bank configuration">
       <header>
-        <h2>Bank configuration</h2>
+        <h2>Bank Configuration</h2>
         <p>Update the system name, the standard service fee, and savings interest.</p>
       </header>
       <form method="post" class="settings-form">
@@ -195,7 +195,7 @@
 
     <section class="settings-panel" aria-label="Account balances">
       <header>
-        <h2>Manage account balances</h2>
+        <h2>Manage Account Balances</h2>
         <p>Set a new balance or reset an account to zero. Checking and savings accept manual overrides.</p>
       </header>
       <div class="settings-account-grid">

--- a/app/banking/templates/banking/transactions.html
+++ b/app/banking/templates/banking/transactions.html
@@ -41,14 +41,14 @@
 
     <section class="banking-overview" aria-label="Banking transactions">
       <header class="banking-overview__header">
-        <h1>Lifesim — Banking Transactions</h1>
+        <h1>{{ bank_settings.bank_name }} — Banking Transactions</h1>
         <p>
           Review every recorded credit and debit for {{ bank_settings.bank_name }}. Cash movements remain manual so the ledger
           focuses on checking and savings accuracy.
         </p>
       </header>
       <div class="account-activity__transactions" aria-label="Transaction ledger">
-        <h3>Transaction history</h3>
+        <h3>Transaction History</h3>
         <p class="account-activity__description">
           Showing
           {% if pagination.total %}

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -45,14 +45,14 @@
 
     <section class="banking-overview">
       <header class="banking-overview__header">
-        <h1>Lifesim — Banking Transfer</h1>
+        <h1>{{ bank_settings.bank_name }} — Banking Transfer</h1>
         <p>
           Move money through {{ bank_settings.bank_name }} while every transaction is written to the ledger and the
           balances refresh in real time.
         </p>
       </header>
       <div class="transfer-balances" aria-label="Available funds">
-        <h2>Available funds</h2>
+        <h2>Available Funds</h2>
         <p>Check balances before you submit a transfer to keep cash, checking, and savings aligned.</p>
         <div class="account-grid">
           {% for account in accounts %}
@@ -72,7 +72,7 @@
       </div>
       <div class="transfer-panel" aria-label="Manage cash movement">
         <article class="transfer-card transfer-card--wide">
-          <h2>Transfer funds</h2>
+          <h2>Transfer Funds</h2>
           <p>Move money between any two accounts. The system enforces minimum balances and records the ledger entries for checking and savings.</p>
           <form
             id="form-account-transfer"
@@ -131,7 +131,7 @@
             <p class="form-feedback" data-feedback hidden></p>
           </form>
           <section class="transfer-requirements" aria-label="Account requirements">
-            <h3>Minimum balance guardrails</h3>
+            <h3>Minimum Balance Guardrails</h3>
             <ul>
               <li>
                 <strong>Checking:</strong>


### PR DESCRIPTION
## Summary
- ensure banking due amounts surface upcoming service fees with contextual guidance
- tighten the banking overview layout by reducing card sizing, stretching columns, and showing due tips
- update banking templates so page headers honor the configured bank name and all headings use title case

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfea2b18908321bff28653b15dd892