### PR TITLE
Fix account opening deposit sum and add tests

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -414,7 +414,7 @@ def api_open_accounts():
     if not selections:
         return _json_error("Choose an account to open and include a starting deposit.")
 
-    total_deposit = sum(amount for _, amount in selections)
+    total_deposit = sum(amount for _, amount, _ in selections)
     if total_deposit > cash_account.balance:
         available = format_currency(cash_account.balance)
         return _json_error(

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,13 @@
 # Lifesim change log
+## 2025-09-28
+- **What**: Fixed the account opening API to total deposits correctly and added test coverage.
+- **How**: Updated the sum operation in `banking/routes.py` to unpack the full selection tuple and
+  introduced a pytest verifying `/banking/api/accounts/open` accepts valid payloads and responds
+  with the expected JSON.
+- **Why**: The previous implementation raised a `ValueError` during tuple unpacking, preventing
+  players from opening accounts even with valid deposits.
+- **Purpose**: Keeps the onboarding workflow reliable and protects against regressions by
+  exercising the happy-path API response in automated tests.
 ## 2025-09-27
 - **What**: Moved the bank account onboarding workflow from the main hub to the banking home page and restored the
   account opening interaction.

--- a/tests/test_banking_routes.py
+++ b/tests/test_banking_routes.py
@@ -1,0 +1,70 @@
+"""Tests for banking routes covering account opening flows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+from sqlalchemy.pool import StaticPool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+
+
+class TestingConfig(Config):
+    """Configuration tuned for isolated unit tests."""
+
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "connect_args": {"check_same_thread": False},
+        "poolclass": StaticPool,
+    }
+
+
+@pytest.fixture()
+def app():
+    """Create a Flask app instance backed by an in-memory database."""
+
+    application = create_app(TestingConfig)
+    yield application
+    with application.app_context():
+        db.drop_all()
+        db.session.remove()
+
+
+@pytest.fixture()
+def client(app):
+    """Provide a Flask test client for request assertions."""
+
+    return app.test_client()
+
+
+def test_api_open_accounts_accepts_valid_payload(client):
+    """Valid account opening requests should succeed and return updated balances."""
+
+    payload = {
+        "accounts": {
+            "checking": {"deposit": "100.00"},
+            "savings": {"deposit": "50"},
+        }
+    }
+
+    response = client.post("/banking/api/accounts/open", json=payload)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert (
+        data["message"]
+        == "Opened Checking Account, Savings Account with $150.00 transferred from cash."
+    )
+    assert data["cash_balance"] == "$350.00"
+    account_names = {account["name"] for account in data["accounts"]}
+    assert {"Checking Account", "Savings Account"} <= account_names


### PR DESCRIPTION
## Summary
- fix the `/banking/api/accounts/open` total deposit calculation so tuple unpacking does not raise
- add a pytest to confirm opening checking and savings accounts succeeds and returns the expected payload
- document the fix and new coverage in `logs.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff5d982d48321bcccbd4994da496e