### PR TITLE
Refine banking availability and settings UI

### DIFF
--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -19,20 +19,22 @@
         >
           Banking Home
         </a>
-        <a
-          href="{{ url_for('banking.insights') }}"
-          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
-          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
-        >
-          Account Insights
-        </a>
-        <a
-          href="{{ url_for('banking.transfer') }}"
-          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-        >
-          Banking Transfer
-        </a>
+        {% if has_bank_accounts %}
+          <a
+            href="{{ url_for('banking.insights') }}"
+            class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+            {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+          >
+            Account Insights
+          </a>
+          <a
+            href="{{ url_for('banking.transfer') }}"
+            class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+            {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+          >
+            Banking Transfer
+          </a>
+        {% endif %}
         <a
           href="{{ url_for('banking.settings') }}"
           class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
@@ -75,80 +77,79 @@
         </section>
       {% endif %}
 
-      <section class="account-activity" aria-label="Account activity">
-        <div class="account-activity__grid">
-          <div class="account-activity__transactions" aria-label="Recent transactions">
-            <h3>Recent Transactions</h3>
-            {% if recent_transactions %}
-              <ul class="transaction-list">
-                {% for transaction in recent_transactions %}
-                  <li class="transaction-list__item" data-direction="{{ transaction.direction }}">
-                    <div class="transaction-list__row">
-                      <span class="transaction-list__name">{{ transaction.name }}</span>
-                      <span class="transaction-list__amount">{{ transaction.amount_display }}</span>
-                    </div>
-                    <p class="transaction-list__meta">{{ transaction.account_name }} · {{ transaction.timestamp }}</p>
-                    <p class="transaction-list__description">{{ transaction.description }}</p>
-                  </li>
-                {% endfor %}
-              </ul>
-              {% if has_more_transactions %}
-                <span
-                  class="transaction-view-more"
-                  role="link"
-                  tabindex="0"
-                  data-view-more="{{ url_for('banking.transactions') }}"
-                >
-                  View more
-                </span>
+      {% if has_bank_accounts %}
+        <section class="account-activity" aria-label="Account activity">
+          <div class="account-activity__grid">
+            <div class="account-activity__transactions" aria-label="Recent transactions">
+              <h3>Recent Transactions</h3>
+              {% if recent_transactions %}
+                <ul class="transaction-list">
+                  {% for transaction in recent_transactions %}
+                    <li class="transaction-list__item" data-direction="{{ transaction.direction }}">
+                      <div class="transaction-list__row">
+                        <span class="transaction-list__name">{{ transaction.name }}</span>
+                        <span class="transaction-list__amount">{{ transaction.amount_display }}</span>
+                      </div>
+                      <p class="transaction-list__meta">{{ transaction.account_name }} · {{ transaction.timestamp }}</p>
+                      <p class="transaction-list__description">{{ transaction.description }}</p>
+                    </li>
+                  {% endfor %}
+                </ul>
+                {% if has_more_transactions %}
+                  <span
+                    class="transaction-view-more"
+                    role="link"
+                    tabindex="0"
+                    data-view-more="{{ url_for('banking.transactions') }}"
+                  >
+                    View more
+                  </span>
+                {% endif %}
+              {% else %}
+                <p class="transaction-list__empty">
+                  No transactions recorded yet. Transfers will appear here automatically.
+                </p>
               {% endif %}
-            {% else %}
-              <p class="transaction-list__empty">
-                No transactions recorded yet. Transfers will appear here automatically.
-              </p>
-            {% endif %}
-          </div>
-          <div class="account-activity__balances" aria-label="Account balances">
-            <h3>Account Balances</h3>
-            {% if not has_open_accounts %}
-              <p class="account-activity__empty">
-                No banking accounts are open yet. Use the Open Account action above to get started.
-              </p>
-            {% endif %}
-            <div class="account-grid">
-              {% for account in accounts %}
-                <article class="account-card" data-account-card data-account="{{ account.id }}">
-                  <header>
-                    {% if account.type %}
-                      <p class="account-card__type">{{ account.type }}</p>
-                    {% endif %}
-                    <h2>{{ account.name }}</h2>
-                  </header>
-                  <p class="account-card__balance">
-                    <span data-balance-value>{{ account.display_balance }}</span>
-                  </p>
-                </article>
-              {% endfor %}
             </div>
-            <section class="account-due" aria-label="Account due summary">
-              <h4>Account Due</h4>
-              <div class="account-due__grid">
-                {% for due in account_due_cards %}
-                  <article class="account-due__card">
+            <div class="account-activity__balances" aria-label="Account balances">
+              <h3>Account Balances</h3>
+              <div class="account-grid">
+                {% for account in accounts %}
+                  <article class="account-card" data-account-card data-account="{{ account.id }}">
                     <header>
-                      <h5>{{ due.name }}</h5>
-                      <span class="account-due__label">Amount Due</span>
+                      {% if account.type %}
+                        <p class="account-card__type">{{ account.type }}</p>
+                      {% endif %}
+                      <h2>{{ account.name }}</h2>
                     </header>
-                    <p class="account-due__amount">{{ due.amount }}</p>
-                    <p class="account-due__note">{{ due.due_date }}</p>
-                    <p class="account-due__tip">{{ due.tip }}</p>
+                    <p class="account-card__balance">
+                      <span data-balance-value>{{ account.display_balance }}</span>
+                    </p>
                   </article>
                 {% endfor %}
               </div>
-            </section>
+              {% if account_due_cards %}
+                <section class="account-due" aria-label="Account due summary">
+                  <h4>Account Due</h4>
+                  <div class="account-due__grid">
+                    {% for due in account_due_cards %}
+                      <article class="account-due__card">
+                        <header>
+                          <h5>{{ due.name }}</h5>
+                          <span class="account-due__label">Amount Due</span>
+                        </header>
+                        <p class="account-due__amount">{{ due.amount }}</p>
+                        <p class="account-due__note">{{ due.due_date }}</p>
+                        <p class="account-due__tip">{{ due.tip }}</p>
+                      </article>
+                    {% endfor %}
+                  </div>
+                </section>
+              {% endif %}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      {% endif %}
     </section>
 
     <div class="modal" id="account-opening-modal" role="dialog" aria-modal="true" aria-labelledby="account-opening-title" hidden>

--- a/app/banking/templates/banking/insights.html
+++ b/app/banking/templates/banking/insights.html
@@ -15,20 +15,22 @@
         >
           Banking Home
         </a>
-        <a
-          href="{{ url_for('banking.insights') }}"
-          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
-          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
-        >
-          Account Insights
-        </a>
-        <a
-          href="{{ url_for('banking.transfer') }}"
-          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-        >
-          Banking Transfer
-        </a>
+        {% if has_bank_accounts %}
+          <a
+            href="{{ url_for('banking.insights') }}"
+            class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+            {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+          >
+            Account Insights
+          </a>
+          <a
+            href="{{ url_for('banking.transfer') }}"
+            class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+            {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+          >
+            Banking Transfer
+          </a>
+        {% endif %}
         <a
           href="{{ url_for('banking.settings') }}"
           class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
@@ -47,92 +49,90 @@
           each transfer with confidence.
         </p>
       </header>
-      <div class="insights-layout">
-        <section class="insight-panel" aria-label="Anchor dates">
-          <header class="insight-panel__header">
-            <h2>Anchor Timelines</h2>
-            <p>See when each account started, when reviews occur, and what balances keep fees away.</p>
-          </header>
-          <div class="insight-panel__grid">
-            {% for key in ("checking", "savings") %}
-              {% set insight = account_insights[key] %}
-              <article class="insight-summary">
-                <header class="insight-summary__header">
-                  <h3>{{ insight.name }}</h3>
-                  <span class="insight-status{% if insight.is_open %} insight-status--open{% else %} insight-status--closed{% endif %}">
-                    {% if insight.is_open %}Open{% else %}Not open{% endif %}
-                  </span>
-                </header>
-                <dl class="insight-summary__details">
-                  <div>
-                    <dt>Account opened</dt>
-                    <dd>{% if insight.is_open %}{{ insight.opened }}{% else %}Pending account opening{% endif %}</dd>
-                  </div>
-                  <div>
-                    <dt>Next anchor date</dt>
-                    <dd>{{ insight.next_anchor }}</dd>
-                  </div>
-                  <div>
-                    <dt>Minimum balance</dt>
-                    <dd>{{ insight.minimum_balance }}</dd>
-                  </div>
-                  <div>
-                    <dt>Fee if below</dt>
-                    <dd>{{ insight.fee }}</dd>
-                  </div>
-                </dl>
-              </article>
-            {% endfor %}
-          </div>
-        </section>
+      {% if has_bank_accounts %}
+        <div class="insights-layout">
+          {% if insight_accounts %}
+            <section class="insight-panel" aria-label="Anchor dates">
+              <header class="insight-panel__header">
+                <h2>Anchor Timelines</h2>
+                <p>See when each account started, when reviews occur, and what balances keep fees away.</p>
+              </header>
+              <div class="insight-panel__grid">
+                {% for insight in insight_accounts %}
+                  <article class="insight-summary">
+                    <header class="insight-summary__header">
+                      <h3>{{ insight.name }}</h3>
+                      <span class="insight-status insight-status--open">Open</span>
+                    </header>
+                    <dl class="insight-summary__details">
+                      <div>
+                        <dt>Account opened</dt>
+                        <dd>{{ insight.opened }}</dd>
+                      </div>
+                      <div>
+                        <dt>Next anchor date</dt>
+                        <dd>{{ insight.next_anchor }}</dd>
+                      </div>
+                      <div>
+                        <dt>Minimum balance</dt>
+                        <dd>{{ insight.minimum_balance }}</dd>
+                      </div>
+                      <div>
+                        <dt>Fee if below</dt>
+                        <dd>{{ insight.fee }}</dd>
+                      </div>
+                    </dl>
+                  </article>
+                {% endfor %}
+              </div>
+            </section>
+          {% endif %}
 
-        <section class="insight-panel" aria-label="Savings interest outlook">
-          <header class="insight-panel__header">
-            <h2>Interest Outlook</h2>
-            <p>
-              Understand how {{ account_insights.savings.apy_rate }} grows your savings and when the next payout is expected.
-            </p>
-          </header>
-          <div class="insight-apy">
-            {% if account_insights.savings.is_open %}
-              <p class="insight-apy__headline">
-                Maintain the current balance to earn <strong>{{ account_insights.savings.projected_interest }}</strong>
-                on {{ account_insights.savings.next_anchor }}.
-              </p>
-              <p class="insight-apy__note">
-                Interest posts on the anchor date and compounds automatically. Deposits before that day increase the payout.
-              </p>
-            {% else %}
-              <p class="insight-apy__headline">
-                Open the savings account to start compounding at {{ account_insights.savings.apy_rate }}.
-              </p>
-              <p class="insight-apy__note">
-                Meeting the opening deposit unlocks the interest schedule and begins tracking growth immediately.
-              </p>
-            {% endif %}
-          </div>
-        </section>
+          {% if has_savings_account %}
+            <section class="insight-panel" aria-label="Savings interest outlook">
+              <header class="insight-panel__header">
+                <h2>Interest Outlook</h2>
+                <p>
+                  Understand how {{ account_insights.savings.apy_rate }} grows your savings and when the next payout is expected.
+                </p>
+              </header>
+              <div class="insight-apy">
+                <p class="insight-apy__headline">
+                  Maintain the current balance to earn <strong>{{ account_insights.savings.projected_interest }}</strong>
+                  on {{ account_insights.savings.next_anchor }}.
+                </p>
+                <p class="insight-apy__note">
+                  Interest posts on the anchor date and compounds automatically. Deposits before that day increase the payout.
+                </p>
+              </div>
+            </section>
+          {% endif %}
 
-        <section class="insight-panel" aria-label="Due date guidance">
-          <header class="insight-panel__header">
-            <h2>Due Date Guidance</h2>
-            <p>Review how to avoid service charges and keep each account compliant ahead of the anchor date.</p>
-          </header>
-          <div class="insight-due-grid">
-            {% for due in account_insights.due_items %}
-              <article class="insight-due-card">
-                <header>
-                  <h3>{{ due.name }}</h3>
-                  <span class="insight-due-label">Amount Due</span>
-                </header>
-                <p class="insight-due-amount">{{ due.amount }}</p>
-                <p class="insight-due-date">{{ due.due_date }}</p>
-                <p class="insight-due-tip">{{ due.tip }}</p>
-              </article>
-            {% endfor %}
-          </div>
-        </section>
-      </div>
+          {% if insight_due_items %}
+            <section class="insight-panel" aria-label="Due date guidance">
+              <header class="insight-panel__header">
+                <h2>Due Date Guidance</h2>
+                <p>Review how to avoid service charges and keep each account compliant ahead of the anchor date.</p>
+              </header>
+              <div class="insight-due-grid">
+                {% for due in insight_due_items %}
+                  <article class="insight-due-card">
+                    <header>
+                      <h3>{{ due.name }}</h3>
+                      <span class="insight-due-label">Amount Due</span>
+                    </header>
+                    <p class="insight-due-amount">{{ due.amount }}</p>
+                    <p class="insight-due-date">{{ due.due_date }}</p>
+                    <p class="insight-due-tip">{{ due.tip }}</p>
+                  </article>
+                {% endfor %}
+              </div>
+            </section>
+          {% endif %}
+        </div>
+      {% else %}
+        <p class="insight-empty">Open a checking or savings account to unlock tailored banking insights.</p>
+      {% endif %}
     </section>
   </div>
 {% endblock %}

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -15,20 +15,22 @@
         >
           Banking Home
         </a>
-        <a
-          href="{{ url_for('banking.insights') }}"
-          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
-          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
-        >
-          Account Insights
-        </a>
-        <a
-          href="{{ url_for('banking.transfer') }}"
-          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-        >
-          Banking Transfer
-        </a>
+        {% if has_bank_accounts %}
+          <a
+            href="{{ url_for('banking.insights') }}"
+            class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+            {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+          >
+            Account Insights
+          </a>
+          <a
+            href="{{ url_for('banking.transfer') }}"
+            class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+            {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+          >
+            Banking Transfer
+          </a>
+        {% endif %}
         <a
           href="{{ url_for('banking.settings') }}"
           class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
@@ -64,32 +66,6 @@
         <p>Align {{ bank_settings.bank_name }} policies, thresholds, and closure fees.</p>
       </header>
 
-      <section class="settings-ledger" aria-label="Policy ledger">
-        <h3>Policy Ledger</h3>
-        <ul class="settings-ledger__list">
-          <li class="settings-ledger__item">
-            <h4>Monthly Service Fee</h4>
-            <p>Assessed when checking or savings fall below their required balance at review.</p>
-          </li>
-          <li class="settings-ledger__item">
-            <h4>Minimum Balances</h4>
-            <p>Defines the cushion that keeps accounts in good standing and avoids penalties.</p>
-          </li>
-          <li class="settings-ledger__item">
-            <h4>Opening Deposits</h4>
-            <p>Cash that must be allocated to unlock a new checking or savings account.</p>
-          </li>
-          <li class="settings-ledger__item">
-            <h4>Savings APY</h4>
-            <p>Controls the annual percentage yield applied to active savings balances.</p>
-          </li>
-          <li class="settings-ledger__item">
-            <h4>Closure Fees</h4>
-            <p>Charged when accounts are closed and funds return to cash reserves.</p>
-          </li>
-        </ul>
-      </section>
-
       <form method="post" class="settings-form">
         <input type="hidden" name="intent" value="update-settings" />
 
@@ -105,20 +81,6 @@
                 required
                 maxlength="120"
               />
-            </label>
-            <label>
-              <span>Bank — Monthly Service Fee</span>
-              <div class="settings-input">
-                <span class="prefix">$</span>
-                <input
-                  type="number"
-                  name="standard_fee"
-                  value="{{ '%.2f'|format(bank_settings.standard_fee) }}"
-                  min="0"
-                  step="0.01"
-                  required
-                />
-              </div>
             </label>
           </div>
         </fieldset>
@@ -291,59 +253,65 @@
     {% set savings_is_closed = savings_account.is_closed if savings_account else False %}
     {% set all_closed = checking_is_closed and savings_is_closed %}
 
-    <section class="settings-panel" aria-label="Account closures">
-      <header>
-        <h2>Account Closures</h2>
-        <p>Return account balances to cash and apply the configured closure fees automatically.</p>
-      </header>
-      <div class="settings-closure-grid">
-        <form method="post" class="settings-closure-card">
-          <input type="hidden" name="intent" value="close-accounts" />
-          <input type="hidden" name="target" value="all" />
-          <h3>Close All Accounts</h3>
-          <p>
-            Move both checking and savings balances into cash. Closure fee:
-            ${{ '%.2f'|format(bank_settings.bank_closure_fee) }}.
-          </p>
-          <button type="submit" class="settings-closure-button" {% if all_closed %}disabled{% endif %}>
-            Close Bank Accounts
-          </button>
-          {% if all_closed %}
-            <p class="settings-closure-note">Checking and savings are already closed.</p>
+    {% if has_bank_accounts %}
+      <section class="settings-panel" aria-label="Account closures">
+        <header>
+          <h2>Account Closures</h2>
+          <p>Return account balances to cash and apply the configured closure fees automatically.</p>
+        </header>
+        <div class="settings-closure-grid">
+          <form method="post" class="settings-closure-card">
+            <input type="hidden" name="intent" value="close-accounts" />
+            <input type="hidden" name="target" value="all" />
+            <h3>Close All Accounts</h3>
+            <p>
+              Move both checking and savings balances into cash. Closure fee:
+              ${{ '%.2f'|format(bank_settings.bank_closure_fee) }}.
+            </p>
+            <button type="submit" class="settings-closure-button" {% if all_closed %}disabled{% endif %}>
+              Close Bank Accounts
+            </button>
+            {% if all_closed %}
+              <p class="settings-closure-note">Checking and savings are already closed.</p>
+            {% endif %}
+          </form>
+          {% if has_checking_account %}
+            <form method="post" class="settings-closure-card">
+              <input type="hidden" name="intent" value="close-accounts" />
+              <input type="hidden" name="target" value="checking" />
+              <h3>Close Checking Account</h3>
+              <p>
+                Transfer the checking balance to cash and charge a
+                ${{ '%.2f'|format(bank_settings.checking_closure_fee) }} closing fee.
+              </p>
+              <button type="submit" class="settings-closure-button" {% if checking_is_closed %}disabled{% endif %}>
+                Close Checking
+              </button>
+              {% if checking_is_closed %}
+                <p class="settings-closure-note">Checking is already closed.</p>
+              {% endif %}
+            </form>
           {% endif %}
-        </form>
-        <form method="post" class="settings-closure-card">
-          <input type="hidden" name="intent" value="close-accounts" />
-          <input type="hidden" name="target" value="checking" />
-          <h3>Close Checking Account</h3>
-          <p>
-            Transfer the checking balance to cash and charge a
-            ${{ '%.2f'|format(bank_settings.checking_closure_fee) }} closing fee.
-          </p>
-          <button type="submit" class="settings-closure-button" {% if checking_is_closed %}disabled{% endif %}>
-            Close Checking
-          </button>
-          {% if checking_is_closed %}
-            <p class="settings-closure-note">Checking is already closed.</p>
+          {% if has_savings_account %}
+            <form method="post" class="settings-closure-card">
+              <input type="hidden" name="intent" value="close-accounts" />
+              <input type="hidden" name="target" value="savings" />
+              <h3>Close Savings Account</h3>
+              <p>
+                Shift the savings balance into cash and apply a
+                ${{ '%.2f'|format(bank_settings.savings_closure_fee) }} closing fee.
+              </p>
+              <button type="submit" class="settings-closure-button" {% if savings_is_closed %}disabled{% endif %}>
+                Close Savings
+              </button>
+              {% if savings_is_closed %}
+                <p class="settings-closure-note">Savings is already closed.</p>
+              {% endif %}
+            </form>
           {% endif %}
-        </form>
-        <form method="post" class="settings-closure-card">
-          <input type="hidden" name="intent" value="close-accounts" />
-          <input type="hidden" name="target" value="savings" />
-          <h3>Close Savings Account</h3>
-          <p>
-            Shift the savings balance into cash and apply a
-            ${{ '%.2f'|format(bank_settings.savings_closure_fee) }} closing fee.
-          </p>
-          <button type="submit" class="settings-closure-button" {% if savings_is_closed %}disabled{% endif %}>
-            Close Savings
-          </button>
-          {% if savings_is_closed %}
-            <p class="settings-closure-note">Savings is already closed.</p>
-          {% endif %}
-        </form>
-      </div>
-    </section>
+        </div>
+      </section>
+    {% endif %}
 
     <section class="settings-panel" aria-label="Account balances">
       <header>

--- a/app/banking/templates/banking/transactions.html
+++ b/app/banking/templates/banking/transactions.html
@@ -15,20 +15,22 @@
         >
           Banking Home
         </a>
-        <a
-          href="{{ url_for('banking.insights') }}"
-          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
-          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
-        >
-          Account Insights
-        </a>
-        <a
-          href="{{ url_for('banking.transfer') }}"
-          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-        >
-          Banking Transfer
-        </a>
+        {% if has_bank_accounts %}
+          <a
+            href="{{ url_for('banking.insights') }}"
+            class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+            {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+          >
+            Account Insights
+          </a>
+          <a
+            href="{{ url_for('banking.transfer') }}"
+            class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+            {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+          >
+            Banking Transfer
+          </a>
+        {% endif %}
         <a
           href="{{ url_for('banking.settings') }}"
           class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -19,20 +19,22 @@
         >
           Banking Home
         </a>
-        <a
-          href="{{ url_for('banking.insights') }}"
-          class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
-          {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
-        >
-          Account Insights
-        </a>
-        <a
-          href="{{ url_for('banking.transfer') }}"
-          class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
-          {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
-        >
-          Banking Transfer
-        </a>
+        {% if has_bank_accounts %}
+          <a
+            href="{{ url_for('banking.insights') }}"
+            class="banking-tab{% if active_banking_tab == 'insights' %} is-active{% endif %}"
+            {% if active_banking_tab == 'insights' %}aria-current="page"{% endif %}
+          >
+            Account Insights
+          </a>
+          <a
+            href="{{ url_for('banking.transfer') }}"
+            class="banking-tab{% if active_banking_tab == 'transfer' %} is-active{% endif %}"
+            {% if active_banking_tab == 'transfer' %}aria-current="page"{% endif %}
+          >
+            Banking Transfer
+          </a>
+        {% endif %}
         <a
           href="{{ url_for('banking.settings') }}"
           class="banking-tab{% if active_banking_tab == 'settings' %} is-active{% endif %}"
@@ -71,83 +73,98 @@
         </div>
       </div>
       <div class="transfer-panel" aria-label="Manage cash movement">
-        <article class="transfer-card transfer-card--wide">
-          <h2>Transfer Funds</h2>
-          <p>Move money between any two accounts. The system enforces minimum balances and records the ledger entries for checking and savings.</p>
-          <form
-            id="form-account-transfer"
-            class="transfer-form"
-            data-endpoint="{{ url_for('banking.api_move') }}"
-          >
-            <div class="form-grid">
-              <label for="account-transfer-source">
-                <span>Source account</span>
-                <select
-                  id="account-transfer-source"
-                  name="source"
-                  required
-                  data-transfer-source
-                >
-                  <option value="" disabled selected>Select a source</option>
-                  {% for account in accounts %}
-                    <option value="{{ account.id }}">{{ account.name }}</option>
-                  {% endfor %}
-                </select>
-              </label>
-              <label for="account-transfer-destination">
-                <span>Destination account</span>
-                <select
-                  id="account-transfer-destination"
-                  name="destination"
-                  required
-                  data-transfer-destination
-                >
-                  <option value="" disabled selected>Select a destination</option>
-                  {% for account in accounts %}
-                    <option value="{{ account.id }}">{{ account.name }}</option>
-                  {% endfor %}
-                </select>
-              </label>
-              <label for="account-transfer-amount" class="form-grid__amount">
-                <span>Amount</span>
-                <input
-                  id="account-transfer-amount"
-                  name="amount"
-                  type="number"
-                  min="0.01"
-                  step="0.01"
-                  required
-                />
-              </label>
-            </div>
-            <div class="transfer-summary" data-transfer-summary data-state="info">
-              Select a source and destination to preview the transfer narrative and guardrails.
-            </div>
-            <div class="transfer-guidelines" data-transfer-guidelines data-state="idle">
-              <div class="transfer-guideline" data-guideline="source" hidden></div>
-              <div class="transfer-guideline" data-guideline="destination" hidden></div>
-            </div>
-            <button type="submit" class="transfer-button">Submit transfer</button>
-            <p class="form-feedback" data-feedback hidden></p>
-          </form>
-          <section class="transfer-requirements" aria-label="Account requirements">
-            <h3>Minimum Balance Guardrails</h3>
-            <ul>
-              <li>
-                <strong>Checking:</strong>
-                Keep {{ '${:,.2f}'.format(bank_settings.checking_minimum_balance) }} on hand or a
-                {{ '${:,.2f}'.format(bank_settings.checking_minimum_fee) }} fee posts on the
-                anchor date.
-              </li>
-              <li>
-                <strong>Savings:</strong>
-                Hold {{ '${:,.2f}'.format(bank_settings.savings_minimum_balance) }} to avoid a
-                {{ '${:,.2f}'.format(bank_settings.savings_minimum_fee) }} maintenance charge when
-                interest credits.
-              </li>
-            </ul>
-          </section>
-        </article>
+        {% if can_transfer %}
+          <article class="transfer-card transfer-card--wide">
+            <h2>Transfer Funds</h2>
+            <p>Move money between any two accounts. The system enforces minimum balances and records the ledger entries for checking and savings.</p>
+            <form
+              id="form-account-transfer"
+              class="transfer-form"
+              data-endpoint="{{ url_for('banking.api_move') }}"
+            >
+              <div class="form-grid">
+                <label for="account-transfer-source">
+                  <span>Source account</span>
+                  <select
+                    id="account-transfer-source"
+                    name="source"
+                    required
+                    data-transfer-source
+                  >
+                    <option value="" disabled selected>Select a source</option>
+                    {% for account in accounts %}
+                      <option value="{{ account.id }}">{{ account.name }}</option>
+                    {% endfor %}
+                  </select>
+                </label>
+                <label for="account-transfer-destination">
+                  <span>Destination account</span>
+                  <select
+                    id="account-transfer-destination"
+                    name="destination"
+                    required
+                    data-transfer-destination
+                  >
+                    <option value="" disabled selected>Select a destination</option>
+                    {% for account in accounts %}
+                      <option value="{{ account.id }}">{{ account.name }}</option>
+                    {% endfor %}
+                  </select>
+                </label>
+                <label for="account-transfer-amount" class="form-grid__amount">
+                  <span>Amount</span>
+                  <input
+                    id="account-transfer-amount"
+                    name="amount"
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    required
+                  />
+                </label>
+              </div>
+              <div class="transfer-summary" data-transfer-summary data-state="info">
+                Select a source and destination to preview the transfer narrative and guardrails.
+              </div>
+              <div class="transfer-guidelines" data-transfer-guidelines data-state="idle">
+                <div class="transfer-guideline" data-guideline="source" hidden></div>
+                <div class="transfer-guideline" data-guideline="destination" hidden></div>
+              </div>
+              <button type="submit" class="transfer-button">Submit transfer</button>
+              <p class="form-feedback" data-feedback hidden></p>
+            </form>
+            {% if has_checking_account or has_savings_account %}
+              <section class="transfer-requirements" aria-label="Account requirements">
+                <h3>Minimum Balance Guardrails</h3>
+                <ul>
+                  {% if has_checking_account %}
+                    <li>
+                      <strong>Checking:</strong>
+                      Keep {{ '${:,.2f}'.format(bank_settings.checking_minimum_balance) }} on hand or a
+                      {{ '${:,.2f}'.format(bank_settings.checking_minimum_fee) }} fee posts on the
+                      anchor date.
+                    </li>
+                  {% endif %}
+                  {% if has_savings_account %}
+                    <li>
+                      <strong>Savings:</strong>
+                      Hold {{ '${:,.2f}'.format(bank_settings.savings_minimum_balance) }} to avoid a
+                      {{ '${:,.2f}'.format(bank_settings.savings_minimum_fee) }} maintenance charge when
+                      interest credits.
+                    </li>
+                  {% endif %}
+                </ul>
+              </section>
+            {% endif %}
+          </article>
+        {% else %}
+          <article class="transfer-card transfer-card--wide">
+            <h2>Transfer Funds</h2>
+            <p>
+              Open a checking or savings account to enable transfers between cash and your banking portfolio.
+            </p>
+          </article>
+        {% endif %}
       </div>
     </section>
 

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,14 @@
 # Lifesim change log
+## 2025-09-29
+- **What**: Streamlined banking visibility by removing the unused policy ledger and monthly service fee field, hiding
+  inaccessible tabs, and gating insights, transfers, and home widgets behind actual account availability.
+- **How**: Trimmed the settings template, updated banking routes with helper flags, filtered insight/due payloads, toggled
+  navigation links, and wrapped template sections so transactions, balances, transfer forms, and closure tools only appear
+  when the user owns the relevant accounts.
+- **Why**: Players without checking or savings access saw misleading options and empty data, while the redundant fee input
+  duplicated account-specific charges.
+- **Purpose**: Keeps the UI focused on actionable controls, clarifies onboarding when no bank accounts exist, and prevents
+  misconfiguration by eliminating obsolete settings.
 ## 2025-09-28
 - **What**: Fixed the account opening API to total deposits correctly and added test coverage.
 - **How**: Updated the sum operation in `banking/routes.py` to unpack the full selection tuple and


### PR DESCRIPTION
## Summary
- hide banking tabs and page modules when no checking or savings accounts exist, including home widgets, insights content, and transfer form
- drop the unused policy ledger and monthly service fee field from banking settings while only showing closure actions for open accounts
- filter insight/due payloads and guardrail messaging so users only see information for accounts they actually own

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cff8a243f48321aff26fff6e245fc5