### PR TITLE
Hide bulk bank closure when only one account is open

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -60,7 +60,7 @@ def _serialize_transaction(transaction: BankTransaction) -> dict[str, object]:
     }
 
 
-def _collect_account_flags(accounts: Iterable[BankAccount]) -> dict[str, bool]:
+def _collect_account_flags(accounts: Iterable[BankAccount]) -> dict[str, bool | int]:
     """Summarize which banking accounts are currently available."""
 
     open_slugs = {
@@ -71,11 +71,13 @@ def _collect_account_flags(accounts: Iterable[BankAccount]) -> dict[str, bool]:
 
     has_checking = "checking" in open_slugs
     has_savings = "savings" in open_slugs
+    open_bank_account_count = len(open_slugs)
 
     return {
         "has_checking": has_checking,
         "has_savings": has_savings,
         "has_bank_accounts": has_checking or has_savings,
+        "open_bank_account_count": open_bank_account_count,
     }
 
 
@@ -984,6 +986,7 @@ def settings():
 
     serialized_accounts = [_serialize_account(account) for account in accounts]
     account_lookup = {account["id"]: account for account in serialized_accounts}
+    can_close_all_accounts = account_flags["open_bank_account_count"] > 1
 
     return render_template(
         "banking/settings.html",
@@ -997,6 +1000,7 @@ def settings():
         has_bank_accounts=account_flags["has_bank_accounts"],
         has_checking_account=account_flags["has_checking"],
         has_savings_account=account_flags["has_savings"],
+        can_close_all_accounts=can_close_all_accounts,
     )
 
 

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -260,21 +260,23 @@
           <p>Return account balances to cash and apply the configured closure fees automatically.</p>
         </header>
         <div class="settings-closure-grid">
-          <form method="post" class="settings-closure-card">
-            <input type="hidden" name="intent" value="close-accounts" />
-            <input type="hidden" name="target" value="all" />
-            <h3>Close All Accounts</h3>
-            <p>
-              Move both checking and savings balances into cash. Closure fee:
-              ${{ '%.2f'|format(bank_settings.bank_closure_fee) }}.
-            </p>
-            <button type="submit" class="settings-closure-button" {% if all_closed %}disabled{% endif %}>
-              Close Bank Accounts
-            </button>
-            {% if all_closed %}
-              <p class="settings-closure-note">Checking and savings are already closed.</p>
-            {% endif %}
-          </form>
+          {% if can_close_all_accounts %}
+            <form method="post" class="settings-closure-card">
+              <input type="hidden" name="intent" value="close-accounts" />
+              <input type="hidden" name="target" value="all" />
+              <h3>Close All Accounts</h3>
+              <p>
+                Move both checking and savings balances into cash. Closure fee:
+                ${{ '%.2f'|format(bank_settings.bank_closure_fee) }}.
+              </p>
+              <button type="submit" class="settings-closure-button" {% if all_closed %}disabled{% endif %}>
+                Close Bank Accounts
+              </button>
+              {% if all_closed %}
+                <p class="settings-closure-note">Checking and savings are already closed.</p>
+              {% endif %}
+            </form>
+          {% endif %}
           {% if has_checking_account %}
             <form method="post" class="settings-closure-card">
               <input type="hidden" name="intent" value="close-accounts" />

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,9 @@
 # Lifesim change log
+## 2025-09-30
+- **What**: Prevented the bulk account closure control from appearing when only one bank account is open.
+- **How**: Counted open banking accounts in the routes helper, passed a new template flag, and wrapped the “Close Bank Accounts” card in a conditional.
+- **Why**: Closing all accounts charged the full bank-wide fee even when a single account remained, penalising players for non-existent closures.
+- **Purpose**: Keeps closure actions aligned with available accounts and avoids surprise fees when only checking or savings is active.
 ## 2025-09-29
 - **What**: Streamlined banking visibility by removing the unused policy ledger and monthly service fee field, hiding
   inaccessible tabs, and gating insights, transfers, and home widgets behind actual account availability.


### PR DESCRIPTION
## Summary
- count open bank accounts when collecting banking flags and expose the result to the settings template
- hide the "Close Bank Accounts" bulk closure card whenever fewer than two accounts are available to prevent unnecessary fees
- log the change in `logs.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d088ffb4248321bcdb78c4266962bf