### PR TITLE
Adjust banking layout typography and inputs

### DIFF
--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -1,5 +1,5 @@
 .banking-shell {
-  width: min(100%, 1200px);
+  width: min(100%, 1000px);
   margin: 0 auto;
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
@@ -69,7 +69,7 @@
 
 .banking-overview__header h1 {
   margin: 0 0 0.5rem;
-  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-size: 1.5rem;
 }
 
 .banking-overview__header p {
@@ -313,7 +313,7 @@
 
 .account-card__balance {
   margin: 0;
-  font-size: clamp(1.15rem, 2.2vw, 1.45rem);
+  font-size: 1.4rem;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
 }
@@ -352,10 +352,13 @@
   gap: 0.5rem;
 }
 
-.account-due__card h5 {
+.account-due__title {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.8rem;
   font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .account-due__label {
@@ -367,7 +370,7 @@
 
 .account-due__amount {
   margin: 0;
-  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  font-size: 1.4rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
@@ -850,7 +853,7 @@
 
 .settings-intro h1 {
   margin: 0;
-  font-size: clamp(2rem, 4vw, 2.4rem);
+  font-size: 1.5rem;
 }
 
 .settings-intro p {
@@ -1012,6 +1015,22 @@
 .settings-account-form label {
   font-weight: 600;
   color: var(--text);
+}
+
+.settings-account-input {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.settings-account-input__prefix {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.settings-account-input input {
+  width: 100%;
 }
 
 .settings-account-actions {

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -135,7 +135,7 @@
                     {% for due in account_due_cards %}
                       <article class="account-due__card">
                         <header>
-                          <h5>{{ due.name }}</h5>
+                          <h5 class="account-due__title">{{ due.name }}</h5>
                           <span class="account-due__label">Amount Due</span>
                         </header>
                         <p class="account-due__amount">{{ due.amount }}</p>

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -338,15 +338,31 @@
               <form method="post" class="settings-account-form">
                 <input type="hidden" name="account_id" value="{{ account.id }}" />
                 <label for="balance-{{ account.id }}">Set balance</label>
-                <input
-                  id="balance-{{ account.id }}"
-                  type="number"
-                  name="amount"
-                  value="{{ '%.2f'|format(account.balance) }}"
-                  min="0"
-                  step="0.01"
-                  required
-                />
+                {% set show_currency_prefix = account.id in ['hand', 'checking', 'savings'] %}
+                {% if show_currency_prefix %}
+                  <div class="settings-account-input">
+                    <span class="settings-account-input__prefix" aria-hidden="true">$</span>
+                    <input
+                      id="balance-{{ account.id }}"
+                      type="number"
+                      name="amount"
+                      value="{{ '%.2f'|format(account.balance) }}"
+                      min="0"
+                      step="0.01"
+                      required
+                    />
+                  </div>
+                {% else %}
+                  <input
+                    id="balance-{{ account.id }}"
+                    type="number"
+                    name="amount"
+                    value="{{ '%.2f'|format(account.balance) }}"
+                    min="0"
+                    step="0.01"
+                    required
+                  />
+                {% endif %}
                 <div class="settings-account-actions">
                   <button type="submit" name="intent" value="update-balance" class="settings-account-save">
                     Save new amount


### PR DESCRIPTION
## Summary
- reduce the banking shell max width and align all banking and settings headers to a 1.5rem size for consistency
- tune balance typography and amount-due labels so values use a 1.4rem size and account names share the account balance label styling
- add currency prefixes to the cash, checking, and savings balance inputs in the banking settings panel

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08c82851c8321bd7633d64134bc4b