### PR TITLE
Standardize banking cards and settings overview

### DIFF
--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -79,6 +79,13 @@
   line-height: 1.55;
 }
 
+.banking-overview__note {
+  margin: 0;
+  color: var(--muted);
+  max-width: 44rem;
+  line-height: 1.55;
+}
+
 .account-activity {
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -282,12 +289,8 @@
 }
 
 .account-card {
-  background: #f9fbff;
-  border: 1px solid #dfe4ec;
-  border-radius: 0.65rem;
-  padding: clamp(0.95rem, 2.2vw, 1.3rem);
-  display: grid;
-  gap: 0.6rem;
+  --summary-card-padding: clamp(0.95rem, 2.2vw, 1.3rem);
+  --summary-card-gap: 0.6rem;
 }
 
 .account-card header {
@@ -337,12 +340,8 @@
 }
 
 .account-due__card {
-  border: 1px solid #dfe4ec;
-  border-radius: 0.65rem;
-  padding: 0.85rem 1rem;
-  background: #f9fbff;
-  display: grid;
-  gap: 0.4rem;
+  --summary-card-padding: 0.85rem 1rem;
+  --summary-card-gap: 0.4rem;
 }
 
 .account-due__card header {
@@ -418,23 +417,27 @@
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.insight-summary {
-  border: 1px solid #e4e9f1;
+.summary-card {
+  --summary-card-padding: 1.25rem;
+  --summary-card-gap: 1rem;
+  --summary-card-background: #f8fafc;
+  --summary-card-border: #e4e9f1;
+  border: 1px solid var(--summary-card-border);
   border-radius: 0.85rem;
-  padding: 1.25rem;
+  padding: var(--summary-card-padding);
   display: grid;
-  gap: 1rem;
-  background: #f8fafc;
+  gap: var(--summary-card-gap);
+  background: var(--summary-card-background);
 }
 
-.insight-summary__header {
+.summary-card__header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 0.75rem;
 }
 
-.insight-summary__header h3 {
+.summary-card__header h3 {
   margin: 0;
   font-size: 1.1rem;
 }
@@ -458,18 +461,18 @@
   color: var(--error);
 }
 
-.insight-summary__details {
+.summary-card__details {
   margin: 0;
   display: grid;
   gap: 0.65rem;
 }
 
-.insight-summary__details div {
+.summary-card__details div {
   display: grid;
   gap: 0.15rem;
 }
 
-.insight-summary__details dt {
+.summary-card__details dt {
   font-size: 0.8rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -477,18 +480,13 @@
   color: var(--muted);
 }
 
-.insight-summary__details dd {
+.summary-card__details dd {
   margin: 0;
   font-weight: 600;
 }
 
 .insight-apy {
-  display: grid;
-  gap: 0.75rem;
-  background: #f1f7ff;
-  border: 1px solid #d6e4fb;
-  border-radius: 0.85rem;
-  padding: 1.25rem;
+  --summary-card-gap: 0.75rem;
 }
 
 .insight-apy__headline {
@@ -510,12 +508,8 @@
 }
 
 .insight-due-card {
-  border: 1px solid #e4e9f1;
-  border-radius: 0.85rem;
-  padding: 1.1rem;
-  background: #f8fafc;
-  display: grid;
-  gap: 0.5rem;
+  --summary-card-padding: 1.1rem;
+  --summary-card-gap: 0.5rem;
 }
 
 .insight-due-card header {
@@ -842,31 +836,6 @@
   line-height: 1.55;
 }
 
-.settings-intro {
-  display: grid;
-  gap: 0.75rem;
-  background: var(--surface);
-  border: 1px solid #dfe4ec;
-  border-radius: 1.05rem;
-  padding: clamp(1.5rem, 4vw, 2.25rem);
-}
-
-.settings-intro h1 {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.settings-intro p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.55;
-}
-
-.settings-note {
-  margin: 0;
-  color: var(--muted);
-}
-
 .settings-alert {
   border-radius: 0.85rem;
   padding: 0.85rem 1.1rem;
@@ -973,12 +942,8 @@
 }
 
 .settings-account-card {
-  background: var(--surface-alt);
-  border: 1px solid #dfe4ec;
-  border-radius: 0.85rem;
-  padding: clamp(1.25rem, 3vw, 1.75rem);
-  display: grid;
-  gap: 1rem;
+  --summary-card-padding: clamp(1.25rem, 3vw, 1.75rem);
+  --summary-card-gap: 1rem;
 }
 
 .settings-account-status {
@@ -1046,12 +1011,8 @@
 }
 
 .settings-closure-card {
-  background: var(--surface-alt);
-  border: 1px solid #dfe4ec;
-  border-radius: 0.85rem;
-  padding: clamp(1.1rem, 2.5vw, 1.5rem);
-  display: grid;
-  gap: 0.75rem;
+  --summary-card-padding: clamp(1.1rem, 2.5vw, 1.5rem);
+  --summary-card-gap: 0.75rem;
 }
 
 .settings-closure-card h3 {

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -115,7 +115,7 @@
               <h3>Account Balances</h3>
               <div class="account-grid">
                 {% for account in accounts %}
-                  <article class="account-card" data-account-card data-account="{{ account.id }}">
+                  <article class="account-card summary-card" data-account-card data-account="{{ account.id }}">
                     <header>
                       {% if account.type %}
                         <p class="account-card__type">{{ account.type }}</p>
@@ -133,7 +133,7 @@
                   <h4>Account Due</h4>
                   <div class="account-due__grid">
                     {% for due in account_due_cards %}
-                      <article class="account-due__card">
+                      <article class="account-due__card summary-card">
                         <header>
                           <h5 class="account-due__title">{{ due.name }}</h5>
                           <span class="account-due__label">Amount Due</span>

--- a/app/banking/templates/banking/insights.html
+++ b/app/banking/templates/banking/insights.html
@@ -59,12 +59,12 @@
               </header>
               <div class="insight-panel__grid">
                 {% for insight in insight_accounts %}
-                  <article class="insight-summary">
-                    <header class="insight-summary__header">
+                  <article class="summary-card">
+                    <header class="summary-card__header">
                       <h3>{{ insight.name }}</h3>
                       <span class="insight-status insight-status--open">Open</span>
                     </header>
-                    <dl class="insight-summary__details">
+                    <dl class="summary-card__details">
                       <div>
                         <dt>Account opened</dt>
                         <dd>{{ insight.opened }}</dd>
@@ -96,7 +96,7 @@
                   Understand how {{ account_insights.savings.apy_rate }} grows your savings and when the next payout is expected.
                 </p>
               </header>
-              <div class="insight-apy">
+              <div class="insight-apy summary-card">
                 <p class="insight-apy__headline">
                   Maintain the current balance to earn <strong>{{ account_insights.savings.projected_interest }}</strong>
                   on {{ account_insights.savings.next_anchor }}.
@@ -116,7 +116,7 @@
               </header>
               <div class="insight-due-grid">
                 {% for due in insight_due_items %}
-                  <article class="insight-due-card">
+                  <article class="insight-due-card summary-card">
                     <header>
                       <h3>{{ due.name }}</h3>
                       <span class="insight-due-label">Amount Due</span>

--- a/app/banking/templates/banking/settings.html
+++ b/app/banking/templates/banking/settings.html
@@ -41,15 +41,15 @@
       </nav>
     </section>
 
-    <section class="settings-intro">
-      <header>
+    <section class="banking-overview" aria-label="Banking settings overview">
+      <header class="banking-overview__header">
         <h1>{{ bank_settings.bank_name }} — Banking Settings</h1>
         <p>
           Configure {{ bank_settings.bank_name }} by defining fees, savings interest, and how much money sits in each
           account.
         </p>
       </header>
-      <p class="settings-note">
+      <p class="banking-overview__note">
         All changes are logged for auditing, and the ledger will reflect new balances immediately.
       </p>
     </section>
@@ -261,7 +261,7 @@
         </header>
         <div class="settings-closure-grid">
           {% if can_close_all_accounts %}
-            <form method="post" class="settings-closure-card">
+            <form method="post" class="settings-closure-card summary-card">
               <input type="hidden" name="intent" value="close-accounts" />
               <input type="hidden" name="target" value="all" />
               <h3>Close All Accounts</h3>
@@ -278,7 +278,7 @@
             </form>
           {% endif %}
           {% if has_checking_account %}
-            <form method="post" class="settings-closure-card">
+            <form method="post" class="settings-closure-card summary-card">
               <input type="hidden" name="intent" value="close-accounts" />
               <input type="hidden" name="target" value="checking" />
               <h3>Close Checking Account</h3>
@@ -295,7 +295,7 @@
             </form>
           {% endif %}
           {% if has_savings_account %}
-            <form method="post" class="settings-closure-card">
+            <form method="post" class="settings-closure-card summary-card">
               <input type="hidden" name="intent" value="close-accounts" />
               <input type="hidden" name="target" value="savings" />
               <h3>Close Savings Account</h3>
@@ -322,7 +322,7 @@
       </header>
       <div class="settings-account-grid">
         {% for account in accounts %}
-          <article class="settings-account-card">
+          <article class="settings-account-card summary-card">
             <header>
               <h3>{{ account.name }}</h3>
               {% if account.type %}

--- a/app/banking/templates/banking/transfer.html
+++ b/app/banking/templates/banking/transfer.html
@@ -58,7 +58,7 @@
         <p>Check balances before you submit a transfer to keep cash, checking, and savings aligned.</p>
         <div class="account-grid">
           {% for account in accounts %}
-            <article class="account-card" data-account-card data-account="{{ account.id }}">
+            <article class="account-card summary-card" data-account-card data-account="{{ account.id }}">
               <header>
                 {% if account.type %}
                   <p class="account-card__type">{{ account.type }}</p>

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,9 @@
 # Lifesim change log
+## 2025-10-01
+- **What**: Unified the styling of banking insight, account, and settings cards and brought the settings overview inline with other banking pages.
+- **How**: Created a reusable `summary-card` pattern with configurable CSS variables, applied it to insights, due summaries, account balances, and closure controls, and swapped the standalone settings intro for the shared banking overview header.
+- **Why**: Disparate card treatments and an isolated settings banner looked inconsistent and made it harder to reuse the layout in new contexts.
+- **Purpose**: Keeps the banking UI cohesive, simplifies future reuse of highlighted cards, and ensures the settings landing matches the presentation established across the module.
 ## 2025-09-30
 - **What**: Prevented the bulk account closure control from appearing when only one bank account is open.
 - **How**: Counted open banking accounts in the routes helper, passed a new template flag, and wrapped the “Close Bank Accounts” card in a conditional.


### PR DESCRIPTION
## Summary
- introduce a reusable `summary-card` style with CSS variables and apply it to insight, account, due, and settings cards
- update banking templates to use the shared card class and align the settings overview with the standard banking header layout
- document the styling unification in the project log for traceability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08fa77594832184c9138ccb8bd5e3