### PR TITLE
Add interactive charts to banking insights

### DIFF
--- a/app/banking/static/js/banking_insights.js
+++ b/app/banking/static/js/banking_insights.js
@@ -1,0 +1,290 @@
+/* Interactive charts for the banking insights view. */
+document.addEventListener("DOMContentLoaded", () => {
+  const chartContainer = document.querySelector("[data-insight-chart]");
+  const dataElement = document.getElementById("insight-chart-data");
+
+  if (!chartContainer || !dataElement) {
+    return;
+  }
+
+  let chartData = [];
+
+  try {
+    const raw = dataElement.textContent?.trim();
+    chartData = raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.error("Failed to parse insight chart data", error);
+    chartData = [];
+  }
+
+  if (!Array.isArray(chartData) || !chartData.length) {
+    return;
+  }
+
+  const focusSelect = chartContainer.querySelector("[data-chart-focus]");
+  const rangeButtons = Array.from(
+    chartContainer.querySelectorAll("[data-chart-range]")
+  );
+  const descriptionDisplay = chartContainer.querySelector(
+    "[data-chart-description]"
+  );
+  const valueDisplay = chartContainer.querySelector("[data-chart-value]");
+  const emptyDisplay = chartContainer.querySelector("[data-chart-empty]");
+  const canvas = document.getElementById("insight-chart-canvas");
+
+  if (!focusSelect || !rangeButtons.length || !canvas) {
+    return;
+  }
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return;
+  }
+
+  const currencyFormatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+
+  const formatValue = (value, format) => {
+    if (!Number.isFinite(value)) {
+      return "—";
+    }
+
+    if (format === "currency") {
+      return currencyFormatter.format(value);
+    }
+
+    return String(value);
+  };
+
+  const toTransparent = (hex, alpha) => {
+    if (typeof hex !== "string" || !hex.startsWith("#")) {
+      return "rgba(37, 99, 235, 0.15)"; // default blue accent
+    }
+
+    const normalized = hex.replace("#", "");
+    const length = normalized.length;
+
+    if (![3, 6].includes(length)) {
+      return "rgba(37, 99, 235, 0.15)";
+    }
+
+    const expand = (value) =>
+      value.length === 1 ? parseInt(value.repeat(2), 16) : parseInt(value, 16);
+    const r = expand(normalized.slice(0, length === 3 ? 1 : 2));
+    const g = expand(normalized.slice(length === 3 ? 1 : 2, length === 3 ? 2 : 4));
+    const b = expand(normalized.slice(length === 3 ? 2 : 4));
+
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  };
+
+  const getSeries = (slug) => chartData.find((entry) => entry.slug === slug);
+
+  const parseDate = (isoString) => {
+    const parsed = new Date(isoString);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  };
+
+  const formatLabel = (isoString, range, dataset) => {
+    const date = parseDate(isoString);
+    if (!date) {
+      return isoString;
+    }
+
+    if (range === "yearly") {
+      return new Intl.DateTimeFormat("en-US", { year: "numeric" }).format(date);
+    }
+
+    if (range === "monthly") {
+      return new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        year: "numeric",
+      }).format(date);
+    }
+
+    const firstDate = parseDate(dataset[0]?.date);
+    const lastDate = parseDate(dataset[dataset.length - 1]?.date);
+    const includeYear =
+      !firstDate || !lastDate
+        ? true
+        : firstDate.getFullYear() !== lastDate.getFullYear();
+
+    const options = includeYear
+      ? { month: "short", day: "numeric", year: "numeric" }
+      : { month: "short", day: "numeric" };
+
+    return new Intl.DateTimeFormat("en-US", options).format(date);
+  };
+
+  const updateRangeButtons = (activeRange) => {
+    rangeButtons.forEach((button) => {
+      const isActive = button.dataset.chartRange === activeRange;
+      button.setAttribute("aria-pressed", String(isActive));
+      button.classList.toggle("is-active", isActive);
+    });
+  };
+
+  let currentRange = "daily";
+  let currentSeries = getSeries(focusSelect.value) || chartData.find((entry) => entry.is_available);
+  let chartInstance = null;
+
+  if (!currentSeries) {
+    const firstOption = chartData[0];
+    if (firstOption) {
+      currentSeries = firstOption;
+      focusSelect.value = firstOption.slug;
+    }
+  }
+
+  const ensureChart = () => {
+    if (chartInstance) {
+      return chartInstance;
+    }
+
+    chartInstance = new Chart(ctx, {
+      type: "line",
+      data: {
+        labels: [],
+        datasets: [],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+          mode: "index",
+          intersect: false,
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const series = getSeries(focusSelect.value);
+                const formatted = formatValue(context.parsed.y, series?.format);
+                return `${series?.name ?? "Value"}: ${formatted}`;
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            grid: {
+              display: false,
+            },
+            ticks: {
+              autoSkip: true,
+              maxTicksLimit: 6,
+            },
+          },
+          y: {
+            ticks: {
+              callback: (value) => {
+                const series = getSeries(focusSelect.value);
+                return formatValue(value, series?.format);
+              },
+            },
+            grid: {
+              color: "rgba(148, 163, 184, 0.2)",
+            },
+          },
+        },
+      },
+    });
+
+    return chartInstance;
+  };
+
+  const applySeries = () => {
+    const series = getSeries(currentSeries?.slug);
+    if (!series) {
+      return;
+    }
+
+    const dataset = series.data?.[currentRange] ?? [];
+
+    if (descriptionDisplay) {
+      descriptionDisplay.textContent = series.description ?? "";
+    }
+
+    if (!dataset.length) {
+      if (emptyDisplay) {
+        emptyDisplay.hidden = false;
+      }
+      canvas.hidden = true;
+      if (valueDisplay) {
+        valueDisplay.textContent = "—";
+      }
+      if (chartInstance) {
+        chartInstance.data.labels = [];
+        chartInstance.data.datasets = [];
+        chartInstance.update();
+      }
+      return;
+    }
+
+    if (emptyDisplay) {
+      emptyDisplay.hidden = true;
+    }
+    canvas.hidden = false;
+
+    const labels = dataset.map((entry) =>
+      formatLabel(entry.date, currentRange, dataset)
+    );
+    const values = dataset.map((entry) => entry.value ?? 0);
+
+    const chart = ensureChart();
+    chart.data.labels = labels;
+    chart.data.datasets = [
+      {
+        label: series.name,
+        data: values,
+        borderColor: series.color,
+        backgroundColor: toTransparent(series.color, 0.15),
+        tension: 0.35,
+        fill: true,
+        pointRadius: 3,
+        pointHoverRadius: 4,
+      },
+    ];
+    chart.update();
+
+    if (valueDisplay) {
+      const lastValue = values[values.length - 1];
+      valueDisplay.textContent = formatValue(lastValue, series.format);
+    }
+  };
+
+  updateRangeButtons(currentRange);
+  applySeries();
+
+  focusSelect.addEventListener("change", (event) => {
+    const target = event.target;
+    if (!target) {
+      return;
+    }
+
+    const nextSeries = getSeries(target.value);
+    if (!nextSeries) {
+      return;
+    }
+
+    currentSeries = nextSeries;
+    applySeries();
+  });
+
+  rangeButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const requestedRange = button.dataset.chartRange;
+      if (!requestedRange || requestedRange === currentRange) {
+        return;
+      }
+      currentRange = requestedRange;
+      updateRangeButtons(currentRange);
+      applySeries();
+    });
+  });
+});

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -417,6 +417,136 @@
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.insight-chart {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.insight-chart__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.insight-chart__focus {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.insight-chart__focus select {
+  appearance: none;
+  border: 1px solid #d1d9e5;
+  border-radius: 0.65rem;
+  padding: 0.45rem 2.25rem 0.45rem 0.75rem;
+  font-weight: 600;
+  color: var(--text);
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='8' viewBox='0 0 14 8'%3e%3cpath fill='%23556676' d='M7 8a.997.997 0 0 1-.707-.293l-6-6L1.707.293 7 5.586 12.293.293l1.414 1.414-6 6A.997.997 0 0 1 7 8Z'/%3e%3c/svg%3e")
+      no-repeat right 0.75rem center / 14px 8px,
+    #ffffff;
+}
+
+.insight-chart__focus select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.insight-chart__ranges {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface-alt);
+}
+
+.insight-chart__ranges button {
+  border: none;
+  background: transparent;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.insight-chart__ranges button:hover,
+.insight-chart__ranges button:focus {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--text);
+  outline: none;
+}
+
+.insight-chart__ranges button.is-active {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.insight-chart__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.insight-chart__description {
+  margin: 0;
+  color: var(--muted);
+  max-width: 40ch;
+}
+
+.insight-chart__value {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.insight-chart__canvas {
+  position: relative;
+  min-height: clamp(220px, 40vw, 320px);
+}
+
+.insight-chart__canvas canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.insight-chart__empty {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  margin: 0;
+  color: var(--muted);
+  text-align: center;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+}
+
+@media (max-width: 640px) {
+  .insight-chart__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .insight-chart__ranges {
+    justify-content: center;
+  }
+
+  .insight-chart__summary {
+    align-items: flex-start;
+  }
+}
+
 .summary-card {
   --summary-card-padding: 1.25rem;
   --summary-card-gap: 1rem;

--- a/app/banking/templates/banking/insights.html
+++ b/app/banking/templates/banking/insights.html
@@ -51,6 +51,52 @@
       </header>
       {% if has_bank_accounts %}
         <div class="insights-layout">
+          {% set available_charts = account_insights.charts | selectattr('is_available') | list %}
+          {% if available_charts %}
+            {% set default_chart = available_charts[0] %}
+            <section class="insight-panel" aria-label="Account performance charts">
+              <header class="insight-panel__header">
+                <h2>Performance Trends</h2>
+                <p>
+                  Compare balances and savings growth with instant views by day, month, or year—no slow scrolling required.
+                </p>
+              </header>
+              <div class="insight-chart" data-insight-chart>
+                <div class="insight-chart__controls">
+                  <label class="insight-chart__focus" for="insight-chart-focus">
+                    Chart focus
+                    <select id="insight-chart-focus" data-chart-focus>
+                      {% for chart in account_insights.charts %}
+                        <option
+                          value="{{ chart.slug }}"
+                          {% if not chart.is_available %}disabled{% endif %}
+                          {% if chart.slug == default_chart.slug %}selected{% endif %}
+                        >
+                          {{ chart.name }}
+                        </option>
+                      {% endfor %}
+                    </select>
+                  </label>
+                  <div class="insight-chart__ranges" role="group" aria-label="Timeframe selection">
+                    <button type="button" data-chart-range="daily" aria-pressed="true">Per Day</button>
+                    <button type="button" data-chart-range="monthly" aria-pressed="false">Per Month</button>
+                    <button type="button" data-chart-range="yearly" aria-pressed="false">Per Year</button>
+                  </div>
+                </div>
+                <div class="insight-chart__summary">
+                  <p class="insight-chart__description" data-chart-description>{{ default_chart.description }}</p>
+                  <p class="insight-chart__value" data-chart-value aria-live="polite">—</p>
+                </div>
+                <div class="insight-chart__canvas">
+                  <canvas id="insight-chart-canvas" role="img" aria-label="Account performance chart"></canvas>
+                  <p class="insight-chart__empty" data-chart-empty hidden>Data is not available for this selection yet.</p>
+                </div>
+              </div>
+              <script type="application/json" id="insight-chart-data">
+                {{ account_insights.charts | tojson }}
+              </script>
+            </section>
+          {% endif %}
           {% if insight_accounts %}
             <section class="insight-panel" aria-label="Anchor dates">
               <header class="insight-panel__header">
@@ -135,4 +181,9 @@
       {% endif %}
     </section>
   </div>
+{% endblock %}
+
+{% block extra_js %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" defer></script>
+  <script src="{{ url_for('banking.static', filename='js/banking_insights.js') }}" defer></script>
 {% endblock %}

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,9 @@
 # Lifesim change log
+## 2025-10-02
+- **What**: Added interactive banking insight charts with timeframe controls for balances and APY earnings.
+- **How**: Generated daily, monthly, and yearly series in `build_account_insights`, rendered a new chart panel with Chart.js, styled the selector UI, and wired client-side logic for smooth switching.
+- **Why**: Players needed quick, uncluttered access to checking, savings, total cash, and interest trends without paging through transaction lists.
+- **Purpose**: Gives users focused visual insight into their money movement and growth so planning transfers or deposits stays fast and informed.
 ## 2025-10-01
 - **What**: Unified the styling of banking insight, account, and settings cards and brought the settings overview inline with other banking pages.
 - **How**: Created a reusable `summary-card` pattern with configurable CSS variables, applied it to insights, due summaries, account balances, and closure controls, and swapped the standalone settings intro for the shared banking overview header.


### PR DESCRIPTION
## Summary
- generate daily, monthly, and yearly balance and APY series on the server
- add a performance trends panel on banking insights with range and chart selectors
- style the chart controls and log the change

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d097363d808321b489aa2830903471