### PR TITLE
Normalize banking insight chart datasets

### DIFF
--- a/app/banking/static/js/banking_insights.js
+++ b/app/banking/static/js/banking_insights.js
@@ -17,6 +17,48 @@ document.addEventListener("DOMContentLoaded", () => {
     chartData = [];
   }
 
+  const createEmptySeriesData = () => ({
+    daily: [],
+    monthly: [],
+    yearly: [],
+  });
+
+  if (!Array.isArray(chartData)) {
+    chartData = [];
+  }
+
+  chartData = chartData.map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return entry;
+    }
+
+    let dataset = entry.data;
+
+    if (typeof dataset === "string") {
+      try {
+        dataset = JSON.parse(dataset);
+      } catch (parseError) {
+        console.error(
+          `Failed to decode insight series data for "${entry.slug ?? entry.name ?? "series"}"`,
+          parseError
+        );
+        dataset = createEmptySeriesData();
+      }
+    }
+
+    const normalized =
+      dataset && typeof dataset === "object" ? dataset : createEmptySeriesData();
+
+    return {
+      ...entry,
+      data: {
+        daily: Array.isArray(normalized.daily) ? normalized.daily : [],
+        monthly: Array.isArray(normalized.monthly) ? normalized.monthly : [],
+        yearly: Array.isArray(normalized.yearly) ? normalized.yearly : [],
+      },
+    };
+  });
+
   if (!Array.isArray(chartData) || !chartData.length) {
     return;
   }


### PR DESCRIPTION
## Summary
- normalize banking insight data by decoding stringified dataset payloads and ensuring object structure
- provide a safe fallback when dataset parsing fails so charts always receive array data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a34f5cfc8321939a37688c0a0cba