### PR TITLE
Add global timezone settings and align banking timelines

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from ..extensions import db
 from ..logging_service import log_manager
+from ..settings.services import format_datetime_for_display
 from . import bp
 from .models import BankAccount, BankSettings, BankTransaction
 from .services import (
@@ -47,7 +48,7 @@ def _serialize_transaction(transaction: BankTransaction) -> dict[str, object]:
 
     account_name = transaction.account.name if transaction.account else "Unknown account"
     sign = "+" if transaction.direction == "credit" else "−"
-    timestamp = transaction.created_at.strftime("%b %d, %Y")
+    timestamp = format_datetime_for_display(transaction.created_at)
 
     return {
         "id": transaction.id,

--- a/app/logging/routes.py
+++ b/app/logging/routes.py
@@ -19,7 +19,11 @@ def console():
         user_summary="Log console opened for review.",
         technical_details="logging.console rendered detailed monitoring interface.",
     )
-    return render_template("logs/console.html", title="Lifesim — Logs")
+    return render_template(
+        "logs/console.html",
+        title="Lifesim — Logs",
+        active_nav="logs",
+    )
 
 
 @bp.route("/feed")

--- a/app/logging_service.py
+++ b/app/logging_service.py
@@ -9,6 +9,7 @@ from flask import current_app
 
 from .extensions import db
 from .models import SystemLog
+from .settings.services import convert_to_active_timezone
 
 
 @dataclass(frozen=True)
@@ -141,7 +142,8 @@ class LogManager:
         record = SystemLog.query.order_by(SystemLog.timestamp.desc()).first()
         if not record:
             return None
-        return record.timestamp.isoformat(timespec="seconds")
+        localized = convert_to_active_timezone(record.timestamp)
+        return localized.isoformat(timespec="seconds")
 
 
 log_manager = LogManager()

--- a/app/models.py
+++ b/app/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Optional
 
 from .extensions import db
+from .settings.services import convert_to_active_timezone
 
 
 class SystemLog(db.Model):
@@ -24,9 +25,10 @@ class SystemLog(db.Model):
 
     def serialize(self) -> dict[str, str]:
         """Return a JSON-serializable representation of the log entry."""
+        localized_timestamp = convert_to_active_timezone(self.timestamp)
         return {
             "id": self.id,
-            "timestamp": self.timestamp.isoformat(timespec="seconds"),
+            "timestamp": localized_timestamp.isoformat(timespec="seconds"),
             "component": self.component,
             "action": self.action,
             "level": self.level,

--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -1,0 +1,11 @@
+"""Blueprint for global Lifesim settings."""
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp = Blueprint(
+    "settings",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+)

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -1,0 +1,20 @@
+"""Database models for global Lifesim settings."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..extensions import db
+
+
+class AppSettings(db.Model):
+    """Persisted configuration shared across the entire application."""
+
+    id: int = db.Column(db.Integer, primary_key=True)
+    timezone: str = db.Column(db.String(64), nullable=False, default="UTC")
+    created_at: datetime = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"<AppSettings timezone={self.timezone}>"

--- a/app/settings/routes.py
+++ b/app/settings/routes.py
@@ -1,0 +1,97 @@
+"""HTTP routes for managing global system settings."""
+from __future__ import annotations
+
+from flask import render_template, request
+from sqlalchemy.exc import SQLAlchemyError
+
+from ..logging_service import log_manager
+from . import bp
+from .services import (
+    describe_timezone,
+    get_app_settings,
+    get_timezone_options,
+    set_timezone,
+)
+
+
+@bp.route("/", methods=["GET", "POST"])
+def preferences():
+    """Display and update system-wide preferences."""
+
+    feedback: dict[str, str] | None = None
+    settings = get_app_settings()
+    timezone_options = get_timezone_options()
+    timezone_values = {option.value for option in timezone_options}
+
+    if request.method == "POST":
+        requested_timezone = request.form.get("timezone", "")
+
+        if requested_timezone not in timezone_values:
+            feedback = {
+                "type": "error",
+                "message": "Select a timezone from the list before saving.",
+            }
+        else:
+            try:
+                set_timezone(requested_timezone)
+            except SQLAlchemyError as exc:
+                log_manager.record(
+                    component="Settings",
+                    action="update-timezone",
+                    level="error",
+                    result="error",
+                    title="Timezone update failed",
+                    user_summary="The system could not save the new timezone. Try again shortly.",
+                    technical_details=(
+                        "settings.set_timezone raised"
+                        f" {exc.__class__.__name__}: {exc}"
+                    ),
+                )
+                feedback = {
+                    "type": "error",
+                    "message": (
+                        "We were unable to update the timezone. Refresh the page and try again."
+                    ),
+                }
+            else:
+                settings = get_app_settings()
+                timezone_label = describe_timezone(settings.timezone)
+                log_manager.record(
+                    component="Settings",
+                    action="update-timezone",
+                    level="info",
+                    result="success",
+                    title="Timezone updated",
+                    user_summary=f"System timezone changed to {timezone_label}.",
+                    technical_details=(
+                        "settings.set_timezone persisted"
+                        f" timezone={settings.timezone}"
+                    ),
+                )
+                feedback = {
+                    "type": "success",
+                    "message": f"Timezone updated to {timezone_label}.",
+                }
+
+    else:
+        log_manager.record(
+            component="Settings",
+            action="view-settings",
+            level="info",
+            result="success",
+            title="Settings viewed",
+            user_summary="System settings page opened to review global preferences.",
+            technical_details="settings.preferences rendered the timezone selector.",
+        )
+
+    timezone_label = describe_timezone(settings.timezone)
+
+    return render_template(
+        "settings/system.html",
+        title="Lifesim — Settings",
+        settings=settings,
+        timezone_options=timezone_options,
+        timezone_label=timezone_label,
+        feedback=feedback,
+        active_nav="settings",
+    )

--- a/app/settings/services.py
+++ b/app/settings/services.py
@@ -1,0 +1,199 @@
+"""Utility functions for managing global Lifesim settings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import List
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ..extensions import db
+from .models import AppSettings
+
+AVAILABLE_TIMEZONES: tuple[tuple[str, str], ...] = (
+    ("UTC", "Coordinated Universal Time"),
+    ("America/New_York", "Eastern Time — US & Canada"),
+    ("America/Chicago", "Central Time — US & Canada"),
+    ("America/Denver", "Mountain Time — US & Canada"),
+    ("America/Los_Angeles", "Pacific Time — US & Canada"),
+    ("Europe/London", "Greenwich Mean Time"),
+    ("Europe/Berlin", "Central European Time"),
+    ("Asia/Kolkata", "India Standard Time"),
+    ("Asia/Tokyo", "Japan Standard Time"),
+    ("Australia/Sydney", "Australian Eastern Time"),
+)
+
+_timezone_cache: dict[str, ZoneInfo] = {}
+_cached_timezone_name: str | None = None
+
+
+@dataclass(frozen=True)
+class TimezoneOption:
+    """Simple representation of a selectable timezone."""
+
+    value: str
+    label: str
+    offset: str
+
+    @property
+    def display_label(self) -> str:
+        """Combine the label and offset for user-friendly rendering."""
+
+        return f"{self.label} ({self.offset})"
+
+
+def _resolve_zoneinfo(name: str) -> ZoneInfo:
+    """Return a ZoneInfo instance for the provided timezone name."""
+
+    zone = _timezone_cache.get(name)
+    if zone:
+        return zone
+    try:
+        zone = ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        zone = ZoneInfo("UTC")
+    _timezone_cache[name] = zone
+    return zone
+
+
+def _normalize_timezone_choice(value: str | None) -> str:
+    """Ensure submitted values map to a supported timezone."""
+
+    valid_names = {choice[0] for choice in AVAILABLE_TIMEZONES}
+    if value in valid_names:
+        return value  # type: ignore[return-value]
+    return "UTC"
+
+
+def ensure_app_settings() -> AppSettings:
+    """Create application settings with defaults when missing."""
+
+    settings = AppSettings.query.first()
+    changed = False
+
+    if not settings:
+        settings = AppSettings(timezone="UTC")
+        db.session.add(settings)
+        changed = True
+    elif not settings.timezone:
+        settings.timezone = "UTC"
+        db.session.add(settings)
+        changed = True
+
+    if changed:
+        db.session.commit()
+
+    return settings
+
+
+def get_app_settings() -> AppSettings:
+    """Return the persisted application settings."""
+
+    return ensure_app_settings()
+
+
+def get_active_timezone_name() -> str:
+    """Return the currently configured timezone identifier."""
+
+    settings = ensure_app_settings()
+    global _cached_timezone_name
+    if _cached_timezone_name != settings.timezone:
+        _cached_timezone_name = settings.timezone or "UTC"
+    return _cached_timezone_name or "UTC"
+
+
+def get_active_timezone() -> ZoneInfo:
+    """Return the ZoneInfo instance for the active timezone."""
+
+    name = get_active_timezone_name()
+    return _resolve_zoneinfo(name)
+
+
+def set_timezone(choice: str) -> AppSettings:
+    """Persist a new timezone selection for the application."""
+
+    settings = ensure_app_settings()
+    settings.timezone = _normalize_timezone_choice(choice)
+    db.session.add(settings)
+    db.session.commit()
+
+    # refresh cache so other components see the update immediately
+    global _cached_timezone_name
+    _cached_timezone_name = settings.timezone
+    _resolve_zoneinfo(settings.timezone)  # prime cache with the updated timezone
+
+    return settings
+
+
+def _format_offset(delta: timedelta | None) -> str:
+    """Return a printable UTC offset string."""
+
+    if delta is None:
+        return "UTC±00:00"
+    minutes = int(delta.total_seconds() // 60)
+    sign = "+" if minutes >= 0 else "-"
+    minutes = abs(minutes)
+    hours, remainder = divmod(minutes, 60)
+    return f"UTC{sign}{hours:02d}:{remainder:02d}"
+
+
+def get_timezone_options() -> list[TimezoneOption]:
+    """Return curated timezone options for the settings interface."""
+
+    now_utc = datetime.now(timezone.utc)
+    options: List[TimezoneOption] = []
+    for value, label in AVAILABLE_TIMEZONES:
+        zone = _resolve_zoneinfo(value)
+        offset = _format_offset(now_utc.astimezone(zone).utcoffset())
+        options.append(TimezoneOption(value=value, label=label, offset=offset))
+    return options
+
+
+def describe_timezone(name: str | None) -> str:
+    """Return a friendly label for the selected timezone."""
+
+    if not name:
+        name = "UTC"
+    for value, label in AVAILABLE_TIMEZONES:
+        if value == name:
+            zone = _resolve_zoneinfo(name)
+            now_utc = datetime.now(timezone.utc)
+            offset = _format_offset(now_utc.astimezone(zone).utcoffset())
+            return f"{label} ({offset})"
+    zone = _resolve_zoneinfo(name)
+    now_utc = datetime.now(timezone.utc)
+    offset = _format_offset(now_utc.astimezone(zone).utcoffset())
+    return f"{name} ({offset})"
+
+
+def convert_to_active_timezone(value: datetime) -> datetime:
+    """Convert a naive UTC datetime to the configured timezone."""
+
+    if not isinstance(value, datetime):
+        raise TypeError("Datetime objects are required for timezone conversion")
+
+    zone = get_active_timezone()
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.astimezone(zone)
+
+
+def current_datetime() -> datetime:
+    """Return the current datetime localized to the active timezone."""
+
+    zone = get_active_timezone()
+    return datetime.now(zone)
+
+
+def current_date() -> date:
+    """Return today's date in the configured timezone."""
+
+    return current_datetime().date()
+
+
+def format_datetime_for_display(value: datetime, fmt: str = "%b %d, %Y") -> str:
+    """Return a formatted datetime string using the active timezone."""
+
+    localized = convert_to_active_timezone(value)
+    return localized.strftime(fmt)

--- a/app/settings/static/js/settings.js
+++ b/app/settings/static/js/settings.js
@@ -1,0 +1,38 @@
+/* Enhance the system settings form with live timezone previews. */
+document.addEventListener("DOMContentLoaded", () => {
+  const select = document.querySelector("[data-timezone-select]");
+  const previewContainer = document.querySelector("[data-timezone-preview]");
+  const previewValue = document.querySelector("[data-timezone-preview-value]");
+  const activeDisplay = document.querySelector("[data-active-timezone]");
+
+  if (!select || !previewValue || !activeDisplay) {
+    return;
+  }
+
+  const buildLabel = (option) => {
+    if (!option) {
+      return "";
+    }
+    const label = option.textContent?.trim() ?? option.value;
+    return label;
+  };
+
+  const updatePreview = () => {
+    const selectedOption = select.options[select.selectedIndex];
+    if (!selectedOption) {
+      return;
+    }
+
+    const label = buildLabel(selectedOption);
+
+    if (previewContainer) {
+      previewContainer.hidden = label === activeDisplay.textContent?.trim();
+    }
+
+    previewValue.textContent = label;
+  };
+
+  select.addEventListener("change", updatePreview);
+
+  updatePreview();
+});

--- a/app/settings/static/styles/settings.css
+++ b/app/settings/static/styles/settings.css
@@ -1,0 +1,189 @@
+.settings-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.settings-header {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+}
+
+.settings-current {
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
+}
+
+.settings-current__label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.settings-current__value {
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.settings-current__note {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.settings-feedback {
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+}
+
+.settings-feedback--success {
+  background: rgba(21, 128, 61, 0.12);
+  color: var(--success);
+  border: 1px solid rgba(21, 128, 61, 0.35);
+}
+
+.settings-feedback--error {
+  background: rgba(185, 28, 28, 0.12);
+  color: var(--error);
+  border: 1px solid rgba(185, 28, 28, 0.35);
+}
+
+.settings-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.settings-form {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-form__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.settings-form__header h2 {
+  margin: 0 0 0.4rem;
+  font-size: 1.4rem;
+}
+
+.settings-form__header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 32rem;
+}
+
+.settings-form__summary {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  min-width: 14rem;
+}
+
+.settings-form__summary-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.settings-form__summary-value {
+  font-weight: 600;
+}
+
+.settings-field {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.settings-field select {
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  font: inherit;
+  color: var(--text);
+}
+
+.settings-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.settings-submit {
+  justify-self: start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: var(--accent);
+  border: none;
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.settings-submit:hover,
+.settings-submit:focus {
+  background: var(--accent-alt);
+}
+
+.settings-impact {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.settings-impact__item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.settings-impact__item h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.settings-impact__item p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .settings-form__header {
+    flex-direction: column;
+  }
+
+  .settings-form__summary {
+    width: 100%;
+  }
+}

--- a/app/settings/templates/settings/system.html
+++ b/app/settings/templates/settings/system.html
@@ -1,0 +1,97 @@
+{% extends "layouts/base.html" %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{{ url_for('settings.static', filename='styles/settings.css') }}" />
+{% endblock %}
+
+{% block extra_js %}
+  <script src="{{ url_for('settings.static', filename='js/settings.js') }}" defer></script>
+{% endblock %}
+
+{% block content %}
+  <div class="settings-shell">
+    <header class="settings-header" aria-labelledby="system-settings-title">
+      <div>
+        <h1 id="system-settings-title">System Preferences</h1>
+        <p>
+          Configure how Lifesim tracks time across every module. The selected timezone controls
+          banking charts, anchor dates, runtime logs, and scheduled reviews.
+        </p>
+      </div>
+      <div class="settings-current" aria-live="polite">
+        <span class="settings-current__label">Active timezone</span>
+        <span class="settings-current__value" data-active-timezone>{{ timezone_label }}</span>
+        <span class="settings-current__note">Applies instantly across modules after saving.</span>
+      </div>
+    </header>
+
+    {% if feedback %}
+      <div class="settings-feedback settings-feedback--{{ feedback.type }}" role="status">
+        {{ feedback.message }}
+      </div>
+    {% endif %}
+
+    <section class="settings-card" aria-label="Timezone configuration">
+      <form method="post" class="settings-form" data-timezone-form>
+        <header class="settings-form__header">
+          <div>
+            <h2>Timezone</h2>
+            <p>
+              Choose a timezone from the curated list. Every timestamp stored in UTC will be
+              presented using your selection.
+            </p>
+          </div>
+          <div class="settings-form__summary" data-timezone-preview hidden>
+            <span class="settings-form__summary-label">Pending selection</span>
+            <span class="settings-form__summary-value" data-timezone-preview-value></span>
+          </div>
+        </header>
+
+        <label class="settings-field">
+          <span>Default timezone</span>
+          <select name="timezone" data-timezone-select>
+            {% for option in timezone_options %}
+              <option
+                value="{{ option.value }}"
+                data-offset="{{ option.offset }}"
+                {% if settings.timezone == option.value %}selected{% endif %}
+              >
+                {{ option.display_label }}
+              </option>
+            {% endfor %}
+          </select>
+        </label>
+
+        <p class="settings-note">
+          All dashboards refresh their timestamps automatically. No manual data entry is required.
+        </p>
+
+        <button type="submit" class="settings-submit">Save timezone</button>
+      </form>
+    </section>
+
+    <section class="settings-impact" aria-label="Timezone impact overview">
+      <article class="settings-impact__item">
+        <h3>Banking timelines</h3>
+        <p>
+          Account charts, anchor dates, and interest projections align with the configured timezone
+          so cash flow snapshots match your day.
+        </p>
+      </article>
+      <article class="settings-impact__item">
+        <h3>Runtime logs</h3>
+        <p>
+          Operational log entries and console updates reflect the same clock, simplifying audits and
+          troubleshooting across teams.
+        </p>
+      </article>
+      <article class="settings-impact__item">
+        <h3>Scheduling</h3>
+        <p>
+          System reminders and review cycles reuse the shared timezone, keeping due dates consistent
+          with your operating hours.
+        </p>
+      </article>
+    </section>
+  </div>
+{% endblock %}

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -21,9 +21,22 @@
           <a href="{{ url_for('real_estate.portfolio') }}" class="nav-item{% if active_nav == 'real_estate' %} active{% endif %}">Real Estate</a>
           <a href="{{ url_for('shop.catalog') }}" class="nav-item{% if active_nav == 'shop' %} active{% endif %}">Shop</a>
           <a href="{{ url_for('job.workspace') }}" class="nav-item{% if active_nav == 'job' %} active{% endif %}">Job</a>
-          <a href="{{ url_for('logging.console') }}" class="nav-item">Logs</a>
+          <a
+            href="{{ url_for('logging.console') }}"
+            class="nav-item{% if active_nav == 'logs' %} active{% endif %}"
+          >
+            Logs
+          </a>
+          <a
+            href="{{ url_for('settings.preferences') }}"
+            class="nav-item{% if active_nav == 'settings' %} active{% endif %}"
+          >
+            Settings
+          </a>
         </nav>
-        <div class="environment">Env: {{ environment|capitalize }}</div>
+        <div class="environment">
+          Env: {{ environment|capitalize }} · TZ: {{ active_timezone_label }}
+        </div>
       </header>
 
       <main class="content" role="main">

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,16 @@
 # Lifesim change log
+## 2025-10-04
+- **What**: Added a global settings center with timezone controls and updated banking timelines to
+  respect the configured zone.
+- **How**: Introduced an `AppSettings` model with a dedicated settings blueprint, built a timezone
+  dropdown fed by curated offsets, wired runtime logging for updates, and converted banking charts,
+  anchor dates, and transaction labels through new timezone utilities while extending the navigation
+  with a Settings link.
+- **Why**: Chart data gaps stemmed from unopened accounts rather than offsets, but players still
+  needed a consistent timezone so performance trends, due dates, and logs stay in sync with their
+  locale.
+- **Purpose**: Centralises system-wide preferences, keeps every module aligned on one clock, and
+  prevents regional differences from hiding activity on insights, ledgers, or runtime diagnostics.
 ## 2025-10-03
 - **What**: Fixed banking insight charts to include every balance change on the day it occurs.
 - **How**: Switched balance timelines to use transaction timestamps, preserved intraday points when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+from sqlalchemy.pool import StaticPool
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import create_app
+from app.config import Config
+from app.extensions import db
+
+
+class TestingConfig(Config):
+    """Configuration tuned for isolated unit tests."""
+
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        "connect_args": {"check_same_thread": False},
+        "poolclass": StaticPool,
+    }
+
+
+@pytest.fixture()
+def app():
+    """Create a Flask app instance backed by an in-memory database."""
+
+    application = create_app(TestingConfig)
+    yield application
+    with application.app_context():
+        db.drop_all()
+        db.session.remove()
+
+
+@pytest.fixture()
+def client(app):
+    """Provide a Flask test client for request assertions."""
+
+    return app.test_client()

--- a/tests/test_banking_routes.py
+++ b/tests/test_banking_routes.py
@@ -2,50 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-import sys
-
-import pytest
-from sqlalchemy.pool import StaticPool
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-from app import create_app
-from app.config import Config
-from app.extensions import db
-
-
-class TestingConfig(Config):
-    """Configuration tuned for isolated unit tests."""
-
-    TESTING = True
-    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
-    SQLALCHEMY_ENGINE_OPTIONS = {
-        "connect_args": {"check_same_thread": False},
-        "poolclass": StaticPool,
-    }
-
-
-@pytest.fixture()
-def app():
-    """Create a Flask app instance backed by an in-memory database."""
-
-    application = create_app(TestingConfig)
-    yield application
-    with application.app_context():
-        db.drop_all()
-        db.session.remove()
-
-
-@pytest.fixture()
-def client(app):
-    """Provide a Flask test client for request assertions."""
-
-    return app.test_client()
-
-
 def test_api_open_accounts_accepts_valid_payload(client):
     """Valid account opening requests should succeed and return updated balances."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from app.settings.services import get_app_settings
+
+
+def test_settings_page_renders(client):
+    """The settings console should load successfully."""
+
+    response = client.get("/settings/")
+
+    assert response.status_code == 200
+    assert b"System Preferences" in response.data
+    assert b"Active timezone" in response.data
+
+
+def test_settings_timezone_update(client, app):
+    """Submitting a timezone selection should persist the change."""
+
+    response = client.post("/settings/", data={"timezone": "America/New_York"})
+
+    assert response.status_code == 200
+    assert b"Timezone updated" in response.data
+
+    with app.app_context():
+        settings = get_app_settings()
+        assert settings.timezone == "America/New_York"


### PR DESCRIPTION
## Summary
- add a system settings blueprint with a timezone selector, dedicated template, and styling so the active zone can be configured without free-form input
- convert banking charts, anchor dates, and rendered transaction timestamps to the configured timezone and surface the active zone in the navigation
- localize log timestamps, register the new settings component, and cover the workflow with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a4cf6c188321bfc5ba38f4299068