### PR TITLE
Fix NameError in banking insights localized date helper

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -134,6 +134,14 @@ def decimal_to_number(value: Decimal | float | int) -> float:
     return float(value)
 
 
+def localized_date(value: datetime | None) -> date | None:
+    """Convert a stored datetime to the active timezone's date."""
+
+    if not value:
+        return None
+    return convert_to_active_timezone(value).date()
+
+
 def ensure_bank_defaults() -> BankSettings:
     """Ensure banking defaults exist before interacting with the system."""
 
@@ -438,11 +446,6 @@ def build_account_due_items(
 
     checking_fee = quantize_amount(settings.checking_minimum_fee)
     savings_fee = quantize_amount(settings.savings_minimum_fee)
-
-    def localized_date(value: datetime | None) -> date | None:
-        if not value:
-            return None
-        return convert_to_active_timezone(value).date()
 
     def format_date(value: date | None) -> str:
         if not value:

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,9 @@
 # Lifesim change log
+## 2025-10-05
+- **What**: Restored the banking insights view by sharing the timezone-aware date formatter across helpers.
+- **How**: Promoted the `localized_date` utility to module scope and reused it from insight builders while trimming the redundant nested version.
+- **Why**: The insights route crashed with a `NameError` after recent refactors, preventing players from reviewing account summaries and charts.
+- **Purpose**: Keeps the insights dashboard stable so creation dates, anchor reminders, and series data render without errors.
 ## 2025-10-04
 - **What**: Added a global settings center with timezone controls and updated banking timelines to
   respect the configured zone.


### PR DESCRIPTION
## Summary
- promote the `localized_date` helper so banking insights can reuse the timezone-aware conversion
- remove the redundant nested implementation that left the insights route without the helper
- document the fix in the changelog to track the restored insights view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0a8894d988321ad74a0e140306c74