### PR TITLE
Ensure banking insight empty state respects hidden attribute

### DIFF
--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -518,6 +518,10 @@
   display: block;
 }
 
+.insight-chart__canvas canvas[hidden] {
+  display: none !important;
+}
+
 .insight-chart__empty {
   position: absolute;
   inset: 0;
@@ -530,6 +534,10 @@
   border: 1px dashed #cbd5e1;
   border-radius: 0.85rem;
   padding: 1.25rem;
+}
+
+.insight-chart__empty[hidden] {
+  display: none !important;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- ensure the banking insights chart canvas and empty-state message hide correctly when the hidden attribute is applied so the empty notice no longer appears alongside rendered data

## Testing
- flask --app run:app --debug run --host 0.0.0.0 (manual verification of insights page)


------
https://chatgpt.com/codex/tasks/task_e_68d0aa8494a88321aa01258cbeda14ec