### PR TITLE
Adjust banking home messaging and styling

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -471,11 +471,7 @@ def build_account_due_items(
                 "amount": format_currency(fee),
                 "due_date": f"Fee posts on {formatted_anchor}",
                 "tip": (
-                    "Deposit {shortfall} before {anchor} to prevent the {fee} service fee."
-                ).format(
-                    shortfall=format_currency(deficit),
-                    anchor=formatted_anchor,
-                    fee=format_currency(fee),
+                    "Balance is below the minimum requirement. Add funds to avoid service fees."
                 ),
             }
 

--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -300,9 +300,11 @@
 
 .account-card header h2 {
   margin: 0;
-  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  font-size: clamp(0.82rem, 1.25vw, 0.95rem);
   font-weight: 600;
   line-height: 1.3;
+  color: var(--muted);
+  letter-spacing: 0.02em;
 }
 
 .account-card__type {

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -113,7 +113,7 @@
             </div>
             <div class="account-activity__balances" aria-label="Account balances">
               <h3>Account Balances</h3>
-              {% set account_label_map = {'checking': 'CHECKING', 'savings': 'SAVINGS'} %}
+              {% set account_label_map = {'checking': 'Checking Account', 'savings': 'Savings Account'} %}
               <div class="account-grid">
                 {% for account in accounts %}
                   {% set account_label = account_label_map.get(account.id, account.name) %}


### PR DESCRIPTION
## Summary
- remove the detailed deposit reminder copy on the banking home due cards to avoid showing specific amounts and dates
- align the checking and savings balance card headings with the "Checking Account"/"Savings Account" naming and tweak the typography for a consistent style

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0af5af7f48321af3af10112fa1762