### PR TITLE
Align banking home card headings and spacing

### DIFF
--- a/app/banking/static/styles/banking.css
+++ b/app/banking/static/styles/banking.css
@@ -122,7 +122,7 @@
 }
 
 .account-activity__transactions h3,
-.account-activity__balances h3 {
+.account-activity__balances h4 {
   margin: 0;
 }
 
@@ -290,21 +290,12 @@
 
 .account-card {
   --summary-card-padding: clamp(0.95rem, 2.2vw, 1.3rem);
-  --summary-card-gap: 0.6rem;
+  --summary-card-gap: 0.3rem;
 }
 
 .account-card header {
   display: grid;
   gap: 0.25rem;
-}
-
-.account-card header h2 {
-  margin: 0;
-  font-size: clamp(0.82rem, 1.25vw, 0.95rem);
-  font-weight: 600;
-  line-height: 1.3;
-  color: var(--muted);
-  letter-spacing: 0.02em;
 }
 
 .account-card__type {
@@ -343,7 +334,7 @@
 
 .account-due__card {
   --summary-card-padding: 0.85rem 1rem;
-  --summary-card-gap: 0.4rem;
+  --summary-card-gap: 0.3rem;
 }
 
 .account-due__card header {
@@ -559,7 +550,7 @@
 
 .summary-card {
   --summary-card-padding: 1.25rem;
-  --summary-card-gap: 1rem;
+  --summary-card-gap: clamp(0.3rem, 0.7vw, 0.5rem);
   --summary-card-background: #f8fafc;
   --summary-card-border: #e4e9f1;
   border: 1px solid var(--summary-card-border);

--- a/app/banking/templates/banking/home.html
+++ b/app/banking/templates/banking/home.html
@@ -112,7 +112,7 @@
               {% endif %}
             </div>
             <div class="account-activity__balances" aria-label="Account balances">
-              <h3>Account Balances</h3>
+              <h4>Account Balances</h4>
               {% set account_label_map = {'checking': 'Checking Account', 'savings': 'Savings Account'} %}
               <div class="account-grid">
                 {% for account in accounts %}
@@ -123,7 +123,7 @@
                       {% if show_account_type %}
                         <p class="account-card__type">{{ account.type }}</p>
                       {% endif %}
-                      <h2>{{ account_label }}</h2>
+                      <h5 class="account-due__title">{{ account_label }}</h5>
                     </header>
                     <p class="account-card__balance">
                       <span data-balance-value>{{ account.display_balance }}</span>
@@ -143,7 +143,6 @@
                         </header>
                         <p class="account-due__amount">{{ due.amount }}</p>
                         <p class="account-due__note">{{ due.due_date }}</p>
-                        <p class="account-due__tip">{{ due.tip }}</p>
                       </article>
                     {% endfor %}
                   </div>


### PR DESCRIPTION
## Summary
- align the Account Balances heading and account titles with the Account Due typography on the banking home page
- remove the fee posts tip text from the account due cards
- tighten spacing within summary cards and adjust related layout selectors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0b5508f84832193b5984b5cf6c685