### PR TITLE
Rebuild job workspace navigation and layout

### DIFF
--- a/app/job/routes.py
+++ b/app/job/routes.py
@@ -19,6 +19,39 @@ def workspace():
         user_summary="Work planning view rendered successfully.",
         technical_details="job.workspace delivered shift planner and productivity widgets.",
     )
+    job_catalog = [
+        {
+            "id": "ux-research",
+            "title": "UX Research Sprint",
+            "rate": "$32/hr",
+            "type": "Contract · Remote",
+            "description": "Interview five customers, synthesize key quotes, and deliver a playback deck by Friday.",
+            "skills": ["User interviews", "Affinity mapping", "Reporting"],
+        },
+        {
+            "id": "support-shift",
+            "title": "Product Support Rotation",
+            "rate": "$28/hr",
+            "type": "Part-time · Hybrid",
+            "description": "Cover live chat, triage bugs, and route feature requests during the afternoon block.",
+            "skills": ["Customer empathy", "Ticket triage", "Product expertise"],
+        },
+        {
+            "id": "ops-optimization",
+            "title": "Operations Optimisation",
+            "rate": "$40/hr",
+            "type": "Freelance · Remote",
+            "description": "Audit recurring workflows, identify automation opportunities, and publish an execution roadmap.",
+            "skills": ["Process design", "Automation", "Stakeholder updates"],
+        },
+    ]
+
+    managed_jobs = [
+        {"title": "Product Consultant", "status": "Active", "rate": "$45/hr", "hours": 12},
+        {"title": "Beta Coordinator", "status": "Paused", "rate": "$30/hr", "hours": 6},
+        {"title": "Design QA", "status": "Draft", "rate": "$25/hr", "hours": 4},
+    ]
+
     shifts = [
         {"day": "Monday", "hours": 4, "activity": "Client project"},
         {"day": "Wednesday", "hours": 3, "activity": "Research"},
@@ -39,10 +72,21 @@ def workspace():
         {"name": "Certification", "deadline": "2024-06-01", "status": "In progress"},
         {"name": "Performance Review", "deadline": "2024-05-15", "status": "Scheduled"},
     ]
+
+    job_preferences = {
+        "auto_assign": True,
+        "default_shift_length": 4,
+        "max_weekly_hours": 24,
+        "notifications": {"email": True, "sms": False},
+        "reminder_window": "1 day before",
+    }
     return render_template(
         "job/workspace.html",
         title="Lifesim — Job",
+        job_catalog=job_catalog,
+        managed_jobs=managed_jobs,
         shifts=shifts,
         milestones=milestones,
+        job_preferences=job_preferences,
         active_nav="job",
     )

--- a/app/job/static/js/job.js
+++ b/app/job/static/js/job.js
@@ -1,5 +1,7 @@
 /* Job workspace enhancements. */
 document.addEventListener("DOMContentLoaded", () => {
+  const jobTabs = document.querySelectorAll("[data-job-tab]");
+  const jobPanels = document.querySelectorAll("[data-job-panel]");
   const rows = document.querySelectorAll(".schedule__table tbody tr");
   const toggle = document.querySelector(".hours-toggle");
   const weeklyTotal = document.getElementById("weekly-total");
@@ -24,12 +26,56 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   };
 
+  const activateTab = (target) => {
+    if (!target) {
+      return;
+    }
+
+    jobTabs.forEach((tab) => {
+      const isActive = tab.dataset.jobTab === target;
+      tab.classList.toggle("is-active", isActive);
+      if (isActive) {
+        tab.setAttribute("aria-current", "page");
+      } else {
+        tab.removeAttribute("aria-current");
+      }
+    });
+
+    jobPanels.forEach((panel) => {
+      const show = panel.dataset.jobPanel === target;
+      panel.classList.toggle("is-active", show);
+      if (show) {
+        panel.removeAttribute("hidden");
+      } else {
+        panel.setAttribute("hidden", "hidden");
+      }
+    });
+
+    if (target === "manage") {
+      calculateTotal();
+      const expanded = toggle ? toggle.classList.contains("is-expanded") : false;
+      highlightFocus(expanded);
+    }
+  };
+
   if (toggle) {
     toggle.addEventListener("click", () => {
       const expanded = toggle.classList.toggle("is-expanded");
       toggle.textContent = expanded ? "Collapse hours" : "Expand hours";
       highlightFocus(expanded);
     });
+  }
+
+  jobTabs.forEach((tab) => {
+    tab.addEventListener("click", (event) => {
+      event.preventDefault();
+      activateTab(tab.dataset.jobTab);
+    });
+  });
+
+  const initialTab = document.querySelector("[data-job-tab].is-active") || jobTabs[0];
+  if (initialTab) {
+    activateTab(initialTab.dataset.jobTab);
   }
 
   calculateTotal();

--- a/app/job/static/styles/job.css
+++ b/app/job/static/styles/job.css
@@ -1,3 +1,379 @@
+.job-shell {
+  width: min(100%, 1000px);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  padding-bottom: clamp(2rem, 5vw, 3rem);
+}
+
+.job-subnav {
+  display: flex;
+  justify-content: center;
+}
+
+.job-tabs {
+  display: flex;
+  gap: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.job-tab {
+  color: var(--muted);
+  text-decoration: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.job-tab:hover,
+.job-tab:focus {
+  background: var(--surface-alt);
+  color: var(--text);
+}
+
+.job-tab.is-active {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+@media (max-width: 640px) {
+  .job-tabs {
+    border-radius: 1rem;
+    justify-content: center;
+  }
+
+  .job-tab {
+    flex: 1 1 45%;
+    text-align: center;
+  }
+}
+
+.job-panels {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.job-panel {
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.75rem;
+  padding: clamp(1.5rem, 4vw, 3.25rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.job-panel[hidden] {
+  display: none;
+}
+
+.job-panel__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+.job-panel__header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  max-width: 46ch;
+  line-height: 1.55;
+}
+
+.job-list {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.job-card {
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 1.5rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.job-card__header h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.2rem;
+}
+
+.job-card__meta {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+  font-size: 0.9rem;
+}
+
+.job-card__description {
+  margin: 0;
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.job-card__details {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.job-card__rate {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: rgba(224, 231, 255, 0.95);
+}
+
+.job-card__skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.job-card__skill {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: rgba(191, 219, 254, 0.9);
+  font-size: 0.85rem;
+}
+
+.job-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.job-card__cta {
+  border: 1px solid rgba(96, 165, 250, 0.7);
+  background: rgba(37, 99, 235, 0.85);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.45rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.job-card__cta--secondary {
+  background: transparent;
+  color: rgba(191, 219, 254, 0.9);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.job-roster {
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.5rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.job-roster__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.job-roster__header h3 {
+  margin: 0;
+}
+
+.job-roster__add {
+  border: 1px solid rgba(96, 165, 250, 0.7);
+  background: transparent;
+  color: rgba(191, 219, 254, 0.95);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.job-roster__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.job-roster__table th,
+.job-roster__table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  text-align: left;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.job-roster__table th:first-child,
+.job-roster__table td:first-child {
+  padding-left: 0;
+}
+
+.job-roster__table th:last-child,
+.job-roster__table td:last-child {
+  padding-right: 0;
+}
+
+.job-roster__table tbody tr:last-child th,
+.job-roster__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.job-roster__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.job-roster__action {
+  border: 1px solid rgba(96, 165, 250, 0.6);
+  background: transparent;
+  color: rgba(191, 219, 254, 0.9);
+  border-radius: 999px;
+  padding: 0.35rem 1rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.job-roster__action--danger {
+  border-color: rgba(248, 113, 113, 0.6);
+  color: rgba(254, 226, 226, 0.95);
+}
+
+.job-manage__grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.job-manage__panels {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+@media (min-width: 960px) {
+  .job-manage__grid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.job-settings {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.job-settings__grid {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 2rem);
+}
+
+.job-settings__group {
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.25rem;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.job-settings__text {
+  max-width: 36ch;
+}
+
+.job-settings__text h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+}
+
+.job-settings__text p {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.9);
+  line-height: 1.55;
+}
+
+.job-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(226, 232, 240, 0.95);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.job-toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.job-settings__control {
+  display: grid;
+  gap: 0.4rem;
+  color: rgba(226, 232, 240, 0.95);
+  font-weight: 600;
+}
+
+.job-settings__label {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+  font-weight: 500;
+}
+
+.job-settings__control input,
+.job-settings__control select {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  color: rgba(226, 232, 240, 0.95);
+  font: inherit;
+}
+
+.job-settings__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.job-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.job-settings__submit {
+  border: 1px solid rgba(96, 165, 250, 0.7);
+  background: rgba(37, 99, 235, 0.85);
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 0.5rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.job-settings__reset {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: transparent;
+  color: rgba(226, 232, 240, 0.85);
+  border-radius: 999px;
+  padding: 0.5rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (max-width: 720px) {
+  .job-settings__group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .job-settings__text {
+    max-width: 100%;
+  }
+}
+
 .job-hero {
   background: linear-gradient(140deg, rgba(244, 114, 182, 0.25), rgba(192, 132, 252, 0.25));
   border-radius: 1.75rem;

--- a/app/job/templates/job/workspace.html
+++ b/app/job/templates/job/workspace.html
@@ -9,55 +9,261 @@
 {% endblock %}
 
 {% block content %}
-  <section class="job-hero">
-    <header>
-      <h1>Lifesim — Job</h1>
-      <p>Structure your workweek, track momentum, and celebrate progress.</p>
-    </header>
-    <div class="hero-insight">
-      <p>Next milestone</p>
-      <strong>{{ milestones[0].name }}</strong>
-      <span>{{ milestones[0].deadline }}</span>
-      <p>Weekly total</p>
-      <span id="weekly-total" class="weekly-total" aria-live="polite"></span>
-    </div>
-  </section>
+  <div class="job-shell">
+    <section class="job-hero">
+      <header>
+        <h1>Lifesim — Job</h1>
+        <p>Structure your workweek, track momentum, and celebrate progress.</p>
+      </header>
+      <div class="hero-insight">
+        <p>Next milestone</p>
+        <strong>{{ milestones[0].name }}</strong>
+        <span>{{ milestones[0].deadline }}</span>
+        <p>Weekly total</p>
+        <span id="weekly-total" class="weekly-total" aria-live="polite"></span>
+      </div>
+    </section>
 
-  <section class="schedule" aria-label="Shift schedule">
-    <header>
-      <h2>Shifts</h2>
-      <button type="button" class="hours-toggle">Expand hours</button>
-    </header>
-    <table class="schedule__table">
-      <thead>
-        <tr>
-          <th scope="col">Day</th>
-          <th scope="col">Hours</th>
-          <th scope="col">Activity</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for shift in shifts %}
-          <tr data-hours="{{ shift.hours }}">
-            <td data-label="Day">{{ shift.day }}</td>
-            <td data-label="Hours">{{ shift.hours }}</td>
-            <td data-label="Activity">{{ shift.activity }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </section>
+    <section class="job-subnav" aria-label="Job navigation">
+      <nav class="job-tabs">
+        <a
+          href="#job-add"
+          class="job-tab is-active"
+          data-job-tab="add"
+          aria-current="page"
+        >
+          Add Job
+        </a>
+        <a href="#job-manage" class="job-tab" data-job-tab="manage">Manage Jobs</a>
+        <a href="#job-settings" class="job-tab" data-job-tab="settings">Job Settings</a>
+      </nav>
+    </section>
 
-  <section class="milestones" aria-label="Career milestones">
-    <h2>Milestones</h2>
-    <div class="milestones__grid">
-      {% for milestone in milestones %}
-        <article class="milestone" data-status="{{ milestone.status }}">
-          <h3>{{ milestone.name }}</h3>
-          <p>Deadline: {{ milestone.deadline }}</p>
-          <p>Status: {{ milestone.status }}</p>
-        </article>
-      {% endfor %}
+    <div class="job-panels">
+      <section
+        class="job-panel is-active"
+        id="job-add"
+        data-job-panel="add"
+        aria-label="Add job"
+      >
+        <header class="job-panel__header">
+          <h2>Available opportunities</h2>
+          <p>Choose new work that fits your schedule and keeps your income diversified.</p>
+        </header>
+        <div class="job-list" role="list">
+          {% for job in job_catalog %}
+            <article class="job-card" data-job="{{ job.id }}" role="listitem">
+              <header class="job-card__header">
+                <h3>{{ job.title }}</h3>
+                <p class="job-card__meta">{{ job.type }}</p>
+              </header>
+              <p class="job-card__description">{{ job.description }}</p>
+              <div class="job-card__details">
+                <span class="job-card__rate">{{ job.rate }}</span>
+                <div class="job-card__skills" aria-label="Key skills">
+                  {% for skill in job.skills %}
+                    <span class="job-card__skill">{{ skill }}</span>
+                  {% endfor %}
+                </div>
+              </div>
+              <footer class="job-card__footer">
+                <button type="button" class="job-card__cta" data-log-action="select-job">
+                  Select job
+                </button>
+                <button type="button" class="job-card__cta job-card__cta--secondary" data-log-action="save-job">
+                  Save for later
+                </button>
+              </footer>
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section
+        class="job-panel"
+        id="job-manage"
+        data-job-panel="manage"
+        aria-label="Manage jobs"
+        hidden
+      >
+        <header class="job-panel__header">
+          <h2>Manage jobs</h2>
+          <p>Reorder commitments, update statuses, and balance your available hours.</p>
+        </header>
+        <div class="job-manage__grid">
+          <section class="job-roster" aria-label="Managed job roster">
+            <header class="job-roster__header">
+              <h3>Active roster</h3>
+              <button type="button" class="job-roster__add">Add new job</button>
+            </header>
+            <table class="job-roster__table">
+              <thead>
+                <tr>
+                  <th scope="col">Job</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Pay</th>
+                  <th scope="col">Weekly hours</th>
+                  <th scope="col" class="job-roster__actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for managed_job in managed_jobs %}
+                  <tr>
+                    <th scope="row">{{ managed_job.title }}</th>
+                    <td>{{ managed_job.status }}</td>
+                    <td>{{ managed_job.rate }}</td>
+                    <td>{{ managed_job.hours }}</td>
+                    <td class="job-roster__actions">
+                      <button type="button" class="job-roster__action">Edit</button>
+                      <button type="button" class="job-roster__action job-roster__action--danger">Remove</button>
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </section>
+
+          <div class="job-manage__panels">
+            <section class="schedule" aria-label="Shift schedule">
+              <header>
+                <h3>Shifts</h3>
+                <button type="button" class="hours-toggle">Expand hours</button>
+              </header>
+              <table class="schedule__table">
+                <thead>
+                  <tr>
+                    <th scope="col">Day</th>
+                    <th scope="col">Hours</th>
+                    <th scope="col">Activity</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for shift in shifts %}
+                    <tr data-hours="{{ shift.hours }}">
+                      <td data-label="Day">{{ shift.day }}</td>
+                      <td data-label="Hours">{{ shift.hours }}</td>
+                      <td data-label="Activity">{{ shift.activity }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </section>
+
+            <section class="milestones" aria-label="Career milestones">
+              <h3>Milestones</h3>
+              <div class="milestones__grid">
+                {% for milestone in milestones %}
+                  <article class="milestone" data-status="{{ milestone.status }}">
+                    <h4>{{ milestone.name }}</h4>
+                    <p>Deadline: {{ milestone.deadline }}</p>
+                    <p>Status: {{ milestone.status }}</p>
+                  </article>
+                {% endfor %}
+              </div>
+            </section>
+          </div>
+        </div>
+      </section>
+
+      <section
+        class="job-panel"
+        id="job-settings"
+        data-job-panel="settings"
+        aria-label="Job settings"
+        hidden
+      >
+        <header class="job-panel__header">
+          <h2>Job settings</h2>
+          <p>Fine-tune automation, reminders, and scheduling defaults for your workload.</p>
+        </header>
+        <form class="job-settings" action="#" method="post">
+          <div class="job-settings__grid">
+            <div class="job-settings__group">
+              <div class="job-settings__text">
+                <h3>Automation</h3>
+                <p>Automatically add selected roles to your managed roster and balance their hours.</p>
+              </div>
+              <label class="job-toggle">
+                <input type="checkbox" name="auto_assign" {% if job_preferences.auto_assign %}checked{% endif %} />
+                <span>Auto-assign selected jobs</span>
+              </label>
+            </div>
+
+            <div class="job-settings__group">
+              <div class="job-settings__text">
+                <h3>Default shift length</h3>
+                <p>Set the number of hours the planner proposes when you create a new shift.</p>
+              </div>
+              <label class="job-settings__control">
+                <span class="job-settings__label">Hours per shift</span>
+                <input
+                  type="number"
+                  name="default_shift_length"
+                  min="1"
+                  max="12"
+                  value="{{ job_preferences.default_shift_length }}"
+                />
+              </label>
+            </div>
+
+            <div class="job-settings__group">
+              <div class="job-settings__text">
+                <h3>Weekly capacity</h3>
+                <p>Control the total time allocation across all roles so you avoid overbooking.</p>
+              </div>
+              <label class="job-settings__control">
+                <span class="job-settings__label">Maximum hours</span>
+                <input
+                  type="number"
+                  name="max_weekly_hours"
+                  min="5"
+                  max="80"
+                  value="{{ job_preferences.max_weekly_hours }}"
+                />
+              </label>
+            </div>
+
+            <div class="job-settings__group">
+              <div class="job-settings__text">
+                <h3>Notifications</h3>
+                <p>Choose how the system keeps you informed about schedule changes and new roles.</p>
+              </div>
+              <div class="job-settings__controls">
+                <label class="job-toggle">
+                  <input type="checkbox" name="notifications[email]" {% if job_preferences.notifications.email %}checked{% endif %} />
+                  <span>Email updates</span>
+                </label>
+                <label class="job-toggle">
+                  <input type="checkbox" name="notifications[sms]" {% if job_preferences.notifications.sms %}checked{% endif %} />
+                  <span>SMS alerts</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="job-settings__group">
+              <div class="job-settings__text">
+                <h3>Reminders</h3>
+                <p>Decide when the planner nudges you ahead of important milestones or shifts.</p>
+              </div>
+              <label class="job-settings__control">
+                <span class="job-settings__label">Reminder timing</span>
+                <select name="reminder_window">
+                  {% set reminder_options = ["2 hours before", "1 day before", "2 days before", "1 week before"] %}
+                  {% for option in reminder_options %}
+                    <option value="{{ option }}" {% if job_preferences.reminder_window == option %}selected{% endif %}>
+                      {{ option }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="job-settings__actions">
+            <button type="submit" class="job-settings__submit">Save preferences</button>
+            <button type="button" class="job-settings__reset">Reset to defaults</button>
+          </div>
+        </form>
+      </section>
     </div>
-  </section>
+  </div>
 {% endblock %}

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -18,9 +18,9 @@
         <nav id="primary-nav" class="primary-nav" aria-label="Main navigation">
           <a href="{{ url_for('index.home') }}" class="nav-item{% if active_nav == 'home' %} active{% endif %}">Home</a>
           <a href="{{ url_for('banking.home') }}" class="nav-item{% if active_nav == 'banking' %} active{% endif %}">Banking</a>
+          <a href="{{ url_for('job.workspace') }}" class="nav-item{% if active_nav == 'job' %} active{% endif %}">Job</a>
           <a href="{{ url_for('real_estate.portfolio') }}" class="nav-item{% if active_nav == 'real_estate' %} active{% endif %}">Real Estate</a>
           <a href="{{ url_for('shop.catalog') }}" class="nav-item{% if active_nav == 'shop' %} active{% endif %}">Shop</a>
-          <a href="{{ url_for('job.workspace') }}" class="nav-item{% if active_nav == 'job' %} active{% endif %}">Job</a>
           <a
             href="{{ url_for('logging.console') }}"
             class="nav-item{% if active_nav == 'logs' %} active{% endif %}"

--- a/logs.md
+++ b/logs.md
@@ -1,4 +1,16 @@
 # Lifesim change log
+## 2025-10-06
+- **What**: Rebuilt the job workspace with tabbed navigation, dedicated panels for adding, managing,
+  and configuring jobs, and aligned the global navigation ordering.
+- **How**: Added catalog, roster, and preference data in the job route, reworked the template with a
+  1000px job shell, sub-navigation, roster table, and settings form, extended the job stylesheet with
+  container, tab, card, and settings patterns, wired tab switching logic in the job script, and moved
+  the Job link between Banking and Real Estate in the base layout.
+- **Why**: The previous workspace only showed a schedule and milestones, leaving no entry point for
+  selecting new jobs or adjusting preferences, and the primary navigation did not match the desired
+  placement.
+- **Purpose**: Establishes the foundational structure for future job features while keeping layout
+  parity with banking and making the new job tools easy to discover.
 ## 2025-10-05
 - **What**: Restored the banking insights view by sharing the timezone-aware date formatter across helpers.
 - **How**: Promoted the `localized_date` utility to module scope and reused it from insight builders while trimming the redundant nested version.


### PR DESCRIPTION
## Summary
- align the primary navigation so the Job link sits between Banking and Real Estate
- expand the job workspace with catalog, roster, and settings panels plus supporting data
- restyle the job module with a 1000px shell, pill tabs, and interactive tab switching

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1053d354883219e1580298b5ea077