### PR TITLE
Add interactive job completion with banking payouts

### DIFF
--- a/app/job/static/js/job_board.js
+++ b/app/job/static/js/job_board.js
@@ -1,0 +1,588 @@
+/* Job board interactions for starting and completing work. */
+
+const parseJSON = (element) => {
+  if (!element) {
+    return null;
+  }
+  try {
+    return JSON.parse(element.textContent || element.value || "");
+  } catch (error) {
+    console.error("Failed to parse job board payload", error);
+    return null;
+  }
+};
+
+const fetchJSON = async (url, options = {}) => {
+  const config = { ...options };
+  config.headers = config.headers ? { ...config.headers } : {};
+  if (
+    config.method &&
+    config.method !== "GET" &&
+    config.body &&
+    !config.headers["Content-Type"]
+  ) {
+    config.headers["Content-Type"] = "application/json";
+  }
+  try {
+    const response = await fetch(url, config);
+    const data = await response.json();
+    if (!response.ok) {
+      return { success: false, message: data?.message || response.statusText };
+    }
+    return data;
+  } catch (error) {
+    return { success: false, message: error.message || "Network request failed." };
+  }
+};
+
+const formatCurrency = (value) => {
+  const amount = Number.isFinite(value) ? value : 0;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  const boardDataElement = document.getElementById("job-board-data");
+  const initialData = parseJSON(boardDataElement) || {};
+
+  const state = {
+    jobs: [],
+    jobMap: new Map(),
+    payoutOptions: Array.isArray(initialData.payout_options)
+      ? initialData.payout_options.filter((option) => option && option.value)
+      : [],
+    settings: initialData.settings || {},
+  };
+
+  if (!state.payoutOptions.some((option) => option.value === "cash")) {
+    state.payoutOptions.unshift({
+      value: "cash",
+      label: "Cash",
+      description: "Receive the payment as cash on hand.",
+      account_slug: "hand",
+    });
+  }
+
+  const jobBoard = document.querySelector(".job-board");
+  if (!jobBoard) {
+    return;
+  }
+
+  const summaryTargets = document.querySelectorAll("[data-job-summary]");
+  const timers = new Map();
+
+  const normalizeJob = (job) => {
+    const sessionStartRaw = job?.active_session_started_at;
+    const sessionStart = sessionStartRaw ? new Date(sessionStartRaw) : null;
+    const hasValidStart = sessionStart && !Number.isNaN(sessionStart.getTime());
+
+    return {
+      ...job,
+      sessionBaseSeconds: Number(job?.active_session_seconds || 0),
+      sessionStart: hasValidStart ? sessionStart : null,
+    };
+  };
+
+  const getSessionSeconds = (job) => {
+    const base = Number(job?.sessionBaseSeconds || 0);
+    if (job?.sessionStart) {
+      const elapsed = Math.max(
+        0,
+        Math.floor((Date.now() - job.sessionStart.getTime()) / 1000)
+      );
+      return base + elapsed;
+    }
+    return base;
+  };
+
+  const calculateRealtimeEarnings = (job, seconds) => {
+    if (job?.pay_type !== "time") {
+      return 0;
+    }
+    const rate = Number(job.rate || 0);
+    if (!Number.isFinite(rate)) {
+      return 0;
+    }
+    const raw = (seconds / 3600) * rate;
+    return Math.ceil(raw * 100) / 100;
+  };
+
+  const formatDuration = (seconds) => {
+    const total = Math.max(0, Number(seconds) || 0);
+    const hrs = Math.floor(total / 3600)
+      .toString()
+      .padStart(2, "0");
+    const mins = Math.floor((total % 3600) / 60)
+      .toString()
+      .padStart(2, "0");
+    const secs = Math.floor(total % 60)
+      .toString()
+      .padStart(2, "0");
+    return `${hrs}:${mins}:${secs}`;
+  };
+
+  const setJobMessage = (jobId, message, tone = "info") => {
+    const card = document.querySelector(
+      `[data-job-card][data-job-id="${jobId}"]`
+    );
+    if (!card) {
+      return;
+    }
+    const messageElement = card.querySelector("[data-job-message]");
+    if (!messageElement) {
+      return;
+    }
+    messageElement.textContent = message || "";
+    messageElement.classList.toggle("job-card__message--error", tone === "error");
+    messageElement.classList.toggle("job-card__message--success", tone === "success");
+  };
+
+  const clearTimer = (jobId) => {
+    const existing = timers.get(jobId);
+    if (existing) {
+      window.clearInterval(existing);
+      timers.delete(jobId);
+    }
+  };
+
+  const updateShift = (job) => {
+    const card = document.querySelector(
+      `[data-job-card][data-job-id="${job.id}"]`
+    );
+    if (!card) {
+      return;
+    }
+    const shift = card.querySelector("[data-job-shift]");
+    const timer = card.querySelector("[data-job-timer]");
+    const earnings = card.querySelector("[data-job-earnings]");
+    if (!shift || !timer || !earnings) {
+      return;
+    }
+    const seconds = Math.max(0, Math.floor(getSessionSeconds(job)));
+    if (seconds <= 0 && !job.sessionStart) {
+      shift.hidden = true;
+      timer.textContent = "00:00:00";
+      earnings.textContent = formatCurrency(0);
+      return;
+    }
+    shift.hidden = false;
+    timer.textContent = formatDuration(seconds);
+    earnings.textContent = formatCurrency(
+      calculateRealtimeEarnings(job, seconds)
+    );
+  };
+
+  const startTimer = (job) => {
+    clearTimer(job.id);
+    updateShift(job);
+    const intervalId = window.setInterval(() => {
+      const current = state.jobMap.get(job.id);
+      if (!current || !current.sessionStart) {
+        clearTimer(job.id);
+        if (current) {
+          updateShift(current);
+        }
+        return;
+      }
+      updateShift(current);
+    }, 1000);
+    timers.set(job.id, intervalId);
+  };
+
+  const updateSummary = () => {
+    const totals = {
+      available: 0,
+      time: 0,
+      task: 0,
+    };
+    state.jobs.forEach((job) => {
+      if (job.is_available) {
+        totals.available += 1;
+      }
+      if (job.pay_type === "time") {
+        totals.time += 1;
+      } else if (job.pay_type === "task") {
+        totals.task += 1;
+      }
+    });
+    summaryTargets.forEach((node) => {
+      const key = node.dataset.jobSummary;
+      if (key && key in totals) {
+        node.textContent = totals[key];
+      }
+    });
+  };
+
+  const updateJobCard = (job) => {
+    const card = document.querySelector(
+      `[data-job-card][data-job-id="${job.id}"]`
+    );
+    if (!card) {
+      return;
+    }
+    card.dataset.jobStatus = job.status;
+    card.dataset.jobType = job.pay_type;
+
+    const statusLabel = card.querySelector("[data-job-status-label]");
+    if (statusLabel) {
+      statusLabel.textContent = job.status_label;
+      statusLabel.className = `job-card__status job-card__status--${job.status}`;
+    }
+
+    const remaining = card.querySelector("[data-job-remaining]");
+    if (remaining) {
+      remaining.textContent = job.remaining_display;
+    }
+
+    const note = card.querySelector("[data-job-note]");
+    if (note) {
+      note.textContent = job.note;
+    }
+
+    const startButton = card.querySelector("[data-job-start]");
+    const pauseButton = card.querySelector("[data-job-pause]");
+    const completeButton = card.querySelector("[data-job-complete]");
+    const hasAvailability =
+      job.remaining_today === null || job.remaining_today > 0;
+    const totalSeconds = Math.max(0, Math.floor(getSessionSeconds(job)));
+
+    if (startButton) {
+      if (job.pay_type === "time") {
+        if (job.sessionStart) {
+          startButton.hidden = true;
+        } else {
+          startButton.hidden = false;
+          startButton.disabled = !hasAvailability;
+          startButton.textContent = totalSeconds > 0 ? "Resume Job" : "Start Job";
+        }
+      } else {
+        startButton.hidden = true;
+      }
+    }
+
+    if (pauseButton) {
+      if (job.pay_type === "time") {
+        pauseButton.hidden = !job.sessionStart;
+        pauseButton.disabled = !job.sessionStart;
+      } else {
+        pauseButton.hidden = true;
+      }
+    }
+
+    if (completeButton) {
+      completeButton.hidden = false;
+      if (job.pay_type === "time") {
+        completeButton.disabled = totalSeconds <= 0;
+      } else {
+        completeButton.disabled = !hasAvailability;
+      }
+    }
+
+    if (job.pay_type === "time") {
+      if (job.sessionStart) {
+        startTimer(job);
+      } else {
+        clearTimer(job.id);
+        updateShift(job);
+      }
+    } else {
+      clearTimer(job.id);
+      updateShift(job);
+    }
+  };
+
+  const setJobState = (job) => {
+    const normalized = normalizeJob(job);
+    state.jobMap.set(normalized.id, normalized);
+    const index = state.jobs.findIndex((item) => item.id === normalized.id);
+    if (index >= 0) {
+      state.jobs[index] = normalized;
+    } else {
+      state.jobs.push(normalized);
+    }
+    updateJobCard(normalized);
+    updateSummary();
+    return normalized;
+  };
+
+  const modal = document.querySelector("[data-job-modal]");
+  const modalTitle = modal?.querySelector("[data-job-modal-title]");
+  const modalMessage = modal?.querySelector("[data-job-modal-message]");
+  const modalOptions = modal?.querySelector("[data-job-modal-options]");
+  const modalOptionsList = modal?.querySelector("[data-job-modal-options-list]");
+  const modalError = modal?.querySelector("[data-job-modal-error]");
+  const modalForm = modal?.querySelector("[data-job-modal-form]");
+  const modalConfirm = modal?.querySelector("[data-job-modal-confirm]");
+  const modalCancel = modal?.querySelector("[data-job-modal-cancel]");
+  const modalClose = modal?.querySelector("[data-job-modal-close]");
+
+  let modalState = null;
+
+  const closeModal = () => {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = true;
+    document.body.classList.remove("job-modal-open");
+    modalState = null;
+  };
+
+  const populatePayoutOptions = () => {
+    if (!modalOptions || !modalOptionsList) {
+      return;
+    }
+    modalOptionsList.innerHTML = "";
+    const options = state.payoutOptions.length
+      ? state.payoutOptions
+      : [
+          {
+            value: "cash",
+            label: "Cash",
+            description: "Receive the payment as cash on hand.",
+            account_slug: "hand",
+          },
+        ];
+    options.forEach((option, index) => {
+      const wrapper = document.createElement("label");
+      wrapper.className = "job-modal__option";
+      const input = document.createElement("input");
+      input.type = "radio";
+      input.name = "payout_method";
+      input.value = option.value;
+      if (index === 0) {
+        input.checked = true;
+      }
+      const title = document.createElement("span");
+      title.className = "job-modal__option-title";
+      title.textContent = option.label || option.value;
+      const description = document.createElement("span");
+      description.className = "job-modal__option-description";
+      description.textContent = option.description || "";
+      wrapper.append(input, title, description);
+      modalOptionsList.append(wrapper);
+    });
+    modalOptions.hidden = options.length === 0;
+  };
+
+  const openModal = (config) => {
+    if (!modal || !modalTitle || !modalMessage || !modalConfirm || !modalError) {
+      return;
+    }
+    modalState = config;
+    modalTitle.textContent = config.title || "";
+    modalMessage.textContent = config.message || "";
+    modalConfirm.textContent = config.confirmLabel || "Confirm";
+    modalConfirm.disabled = false;
+    modalError.textContent = "";
+
+    if (config.requirePayout) {
+      populatePayoutOptions();
+    }
+    if (modalOptions) {
+      modalOptions.hidden = !config.requirePayout;
+    }
+
+    modal.hidden = false;
+    document.body.classList.add("job-modal-open");
+    window.requestAnimationFrame(() => {
+      modalConfirm.focus();
+    });
+  };
+
+  const getSelectedPayout = () => {
+    if (!modalForm) {
+      return null;
+    }
+    const selected = modalForm.querySelector(
+      'input[name="payout_method"]:checked'
+    );
+    return selected ? selected.value : null;
+  };
+
+  const startJobRequest = async (jobId) => {
+    const response = await fetchJSON(`/job/api/jobs/${jobId}/start`, {
+      method: "POST",
+    });
+    if (!response.success) {
+      return response;
+    }
+    setJobState(response.job);
+    return response;
+  };
+
+  const pauseJobRequest = async (jobId) => {
+    const response = await fetchJSON(`/job/api/jobs/${jobId}/pause`, {
+      method: "POST",
+    });
+    if (!response.success) {
+      return response;
+    }
+    setJobState(response.job);
+    return response;
+  };
+
+  const completeJobRequest = async (jobId, payoutMethod) => {
+    const response = await fetchJSON(`/job/api/jobs/${jobId}/complete`, {
+      method: "POST",
+      body: JSON.stringify({ payout_method: payoutMethod }),
+    });
+    if (!response.success) {
+      return response;
+    }
+    setJobState(response.job);
+    return response;
+  };
+
+  if (modalForm) {
+    modalForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!modalState) {
+        return;
+      }
+      modalConfirm.disabled = true;
+      modalError.textContent = "";
+      if (modalState.mode === "start") {
+        const result = await startJobRequest(modalState.jobId);
+        if (!result.success) {
+          modalError.textContent = result.message || "Unable to start this job.";
+          setJobMessage(modalState.jobId, result.message || "Unable to start this job.", "error");
+          modalConfirm.disabled = false;
+          return;
+        }
+        setJobMessage(modalState.jobId, result.message || "Shift started.", "success");
+        closeModal();
+      } else if (modalState.mode === "complete") {
+        const payoutMethod = getSelectedPayout();
+        if (!payoutMethod) {
+          modalError.textContent = "Select how you'd like to receive payment.";
+          modalConfirm.disabled = false;
+          return;
+        }
+        const result = await completeJobRequest(modalState.jobId, payoutMethod);
+        if (!result.success) {
+          modalError.textContent = result.message || "Unable to complete this job.";
+          setJobMessage(modalState.jobId, result.message || "Unable to complete this job.", "error");
+          modalConfirm.disabled = false;
+          return;
+        }
+        setJobMessage(modalState.jobId, result.message || "Job completed.", "success");
+        closeModal();
+      }
+    });
+  }
+
+  if (modalCancel) {
+    modalCancel.addEventListener("click", () => closeModal());
+  }
+  if (modalClose) {
+    modalClose.addEventListener("click", () => closeModal());
+  }
+  if (modal) {
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+  }
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal && !modal.hidden) {
+      closeModal();
+    }
+  });
+
+  jobBoard.addEventListener("click", async (event) => {
+    const startButton = event.target.closest("[data-job-start]");
+    if (startButton) {
+      const card = startButton.closest("[data-job-card]");
+      if (!card || startButton.disabled) {
+        return;
+      }
+      const job = state.jobMap.get(card.dataset.jobId);
+      if (!job) {
+        return;
+      }
+      const totalSeconds = Math.max(0, Math.floor(getSessionSeconds(job)));
+      const isResuming = totalSeconds > 0;
+      openModal({
+        mode: "start",
+        jobId: job.id,
+        title: isResuming ? "Resume shift" : "Start job",
+        message: isResuming
+          ? `Resume tracking time for ${job.title}.`
+          : `Start working on ${job.title}?`,
+        confirmLabel: isResuming ? "Resume" : "Start",
+        requirePayout: false,
+      });
+      return;
+    }
+
+    const pauseButton = event.target.closest("[data-job-pause]");
+    if (pauseButton) {
+      const card = pauseButton.closest("[data-job-card]");
+      if (!card || pauseButton.disabled) {
+        return;
+      }
+      pauseButton.disabled = true;
+      const result = await pauseJobRequest(card.dataset.jobId);
+      pauseButton.disabled = false;
+      if (!result.success) {
+        setJobMessage(card.dataset.jobId, result.message || "Unable to pause this job.", "error");
+        return;
+      }
+      setJobMessage(card.dataset.jobId, result.message || "Shift paused.", "success");
+      return;
+    }
+
+    const completeButton = event.target.closest("[data-job-complete]");
+    if (completeButton) {
+      const card = completeButton.closest("[data-job-card]");
+      if (!card || completeButton.disabled) {
+        return;
+      }
+      const job = state.jobMap.get(card.dataset.jobId);
+      if (!job) {
+        return;
+      }
+      let earningsPreview = 0;
+      if (job.pay_type === "time") {
+        earningsPreview = calculateRealtimeEarnings(job, getSessionSeconds(job));
+      } else if (job.pay_type === "task") {
+        earningsPreview = Number(job.rate || 0);
+      }
+      const previewCopy =
+        earningsPreview > 0
+          ? `You will earn approximately ${formatCurrency(earningsPreview)}.`
+          : "Complete this job to record your earnings.";
+      openModal({
+        mode: "complete",
+        jobId: job.id,
+        title: "Complete job",
+        message: `${job.title} — ${previewCopy}`,
+        confirmLabel: "Complete",
+        requirePayout: true,
+      });
+    }
+  });
+
+  const initialJobs = Array.isArray(initialData.jobs) ? initialData.jobs : [];
+  initialJobs.forEach((job) => {
+    const normalized = normalizeJob(job);
+    state.jobs.push(normalized);
+    state.jobMap.set(normalized.id, normalized);
+    updateJobCard(normalized);
+  });
+  updateSummary();
+  state.jobs.forEach((job) => {
+    if (job.pay_type === "time") {
+      if (job.sessionStart) {
+        startTimer(job);
+      } else {
+        updateShift(job);
+      }
+    }
+  });
+});

--- a/app/job/static/styles/job.css
+++ b/app/job/static/styles/job.css
@@ -222,7 +222,87 @@
 
 .job-card__footer {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.75rem;
+}
+
+.job-card__actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.job-card__shift {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.job-card__timer {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.job-card__earnings {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+}
+
+.job-card__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.job-card__button {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: 0.45rem 0.95rem;
+  border-radius: 0.65rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.job-card__button:hover,
+.job-card__button:focus {
+  background: var(--surface-alt);
+}
+
+.job-card__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.job-card__button--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.job-card__button--primary:hover,
+.job-card__button--primary:focus {
+  filter: brightness(0.95);
+}
+
+.job-card__message {
+  margin: 0;
+  font-size: 0.85rem;
+  min-height: 1.1em;
+  color: var(--muted);
+}
+
+.job-card__message--success {
+  color: var(--success);
+}
+
+.job-card__message--error {
+  color: var(--error);
 }
 
 .job-card__note,
@@ -230,6 +310,151 @@
   margin: 0;
   color: var(--muted);
   font-size: 0.85rem;
+}
+
+.job-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 1000;
+}
+
+.job-modal[hidden] {
+  display: none;
+}
+
+.job-modal__dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  width: min(100%, 420px);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.job-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.job-modal__header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.job-modal__close {
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.job-modal__message {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.job-modal__options {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.job-modal__options legend {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.job-modal__options-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.job-modal__option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.75rem;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  padding: 0.75rem;
+  cursor: pointer;
+}
+
+.job-modal__option input {
+  accent-color: var(--accent);
+}
+
+.job-modal__option-title {
+  font-weight: 600;
+}
+
+.job-modal__option-description {
+  grid-column: 2;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.job-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.job-modal__button {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text);
+  border-radius: 0.65rem;
+  padding: 0.5rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.job-modal__button:hover,
+.job-modal__button:focus {
+  background: var(--surface);
+}
+
+.job-modal__button--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.job-modal__button--primary:hover,
+.job-modal__button--primary:focus {
+  filter: brightness(0.95);
+}
+
+.job-modal__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.job-modal__error {
+  margin: 0;
+  font-size: 0.85rem;
+  min-height: 1.1em;
+  color: var(--error);
+}
+
+body.job-modal-open {
+  overflow: hidden;
 }
 
 .job-guidance {

--- a/app/job/templates/job/listings.html
+++ b/app/job/templates/job/listings.html
@@ -1,7 +1,13 @@
 {% extends "layouts/base.html" %}
 
 {% macro render_job_card(job) %}
-  <article class="job-card" data-job-status="{{ job.status }}">
+  <article
+    class="job-card"
+    data-job-card
+    data-job-id="{{ job.id }}"
+    data-job-type="{{ job.pay_type }}"
+    data-job-status="{{ job.status }}"
+  >
     <header class="job-card__header">
       <div class="job-card__titles">
         <h3>{{ job.title }}</h3>
@@ -20,15 +26,31 @@
       </div>
       <div>
         <dt>Remaining today</dt>
-        <dd>{{ job.remaining_display }}</dd>
+        <dd data-job-remaining>{{ job.remaining_display }}</dd>
       </div>
       <div>
         <dt>Status</dt>
-        <dd class="job-card__status job-card__status--{{ job.status }}">{{ job.status_label }}</dd>
+        <dd class="job-card__status job-card__status--{{ job.status }}" data-job-status-label>
+          {{ job.status_label }}
+        </dd>
       </div>
     </dl>
     <footer class="job-card__footer">
-      <p class="job-card__note">{{ job.note }}</p>
+      <div class="job-card__actions" data-job-actions>
+        <div class="job-card__shift" data-job-shift hidden>
+          <span class="job-card__timer" data-job-timer>00:00:00</span>
+          <span class="job-card__earnings" data-job-earnings>{{ job.active_session_earnings_display }}</span>
+        </div>
+        <div class="job-card__buttons">
+          <button type="button" class="job-card__button" data-job-start hidden>Start Job</button>
+          <button type="button" class="job-card__button" data-job-pause hidden>Pause Job</button>
+          <button type="button" class="job-card__button job-card__button--primary" data-job-complete>
+            Complete Job
+          </button>
+        </div>
+        <p class="job-card__message" data-job-message aria-live="polite"></p>
+      </div>
+      <p class="job-card__note" data-job-note>{{ job.note }}</p>
       <p class="job-card__reset">Resets {{ job.reset_label }}</p>
     </footer>
   </article>
@@ -39,7 +61,7 @@
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{{ url_for('job.static', filename='js/job.js') }}" defer></script>
+  <script src="{{ url_for('job.static', filename='js/job_board.js') }}" defer></script>
 {% endblock %}
 
 {% block content %}
@@ -77,15 +99,15 @@
       </header>
       <div class="job-hero__summary">
         <article class="job-stat">
-          <h2>{{ summary.available }}</h2>
+          <h2 data-job-summary="available">{{ summary.available }}</h2>
           <p>Available today</p>
         </article>
         <article class="job-stat">
-          <h2>{{ summary.time }}</h2>
+          <h2 data-job-summary="time">{{ summary.time }}</h2>
           <p>Time-based roles</p>
         </article>
         <article class="job-stat">
-          <h2>{{ summary.task }}</h2>
+          <h2 data-job-summary="task">{{ summary.task }}</h2>
           <p>Task-based gigs</p>
         </article>
       </div>
@@ -134,6 +156,34 @@
         <p class="job-empty">No jobs are available yet. Visit Manage Jobs to create your first listing.</p>
       {% endif %}
     </section>
+  </div>
+
+  <script
+    type="application/json"
+    id="job-board-data"
+  >{{ {'jobs': jobs, 'settings': settings, 'payout_options': payout_options} | tojson }}</script>
+
+  <div class="job-modal" data-job-modal hidden>
+    <div class="job-modal__dialog" role="dialog" aria-modal="true">
+      <div class="job-modal__header">
+        <h2 data-job-modal-title></h2>
+        <button type="button" class="job-modal__close" data-job-modal-close aria-label="Close">&times;</button>
+      </div>
+      <form class="job-modal__form" data-job-modal-form novalidate>
+        <p class="job-modal__message" data-job-modal-message></p>
+        <fieldset class="job-modal__options" data-job-modal-options hidden>
+          <legend>Choose how to receive payment</legend>
+          <div class="job-modal__options-list" data-job-modal-options-list></div>
+        </fieldset>
+        <p class="job-modal__error" data-job-modal-error aria-live="polite"></p>
+        <div class="job-modal__actions">
+          <button type="button" class="job-modal__button" data-job-modal-cancel>Cancel</button>
+          <button type="submit" class="job-modal__button job-modal__button--primary" data-job-modal-confirm>
+            Confirm
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 {% endblock %}
 

--- a/app/job/templates/job/settings.html
+++ b/app/job/templates/job/settings.html
@@ -44,6 +44,19 @@
         <form class="job-settings__form" data-job-settings-form novalidate>
           <div class="job-settings__message" data-job-settings-message aria-live="polite"></div>
           <label class="job-settings__field">
+            <span>Payroll company name</span>
+            <input
+              type="text"
+              name="payroll_company_name"
+              value="{{ settings.payroll_company_name }}"
+              maxlength="80"
+              required
+              data-job-company-name
+            />
+            <p class="job-form__hint">Shown on bank transactions when jobs pay out.</p>
+          </label>
+
+          <label class="job-settings__field">
             <span>Minimum hourly wage</span>
             <div class="job-form__input-group">
               <span class="job-form__prefix">$</span>

--- a/tests/test_job_services.py
+++ b/tests/test_job_services.py
@@ -1,0 +1,95 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.job.services import JobRepository, JobSettings
+
+
+@pytest.fixture(autouse=True)
+def isolate_job_repository():
+    original_jobs = JobRepository._jobs
+    original_sequence = JobRepository._sequence
+    original_settings = JobRepository._settings
+    JobRepository._jobs = {}
+    JobRepository._sequence = 1
+    JobRepository._settings = JobSettings()
+    try:
+        yield
+    finally:
+        JobRepository._jobs = original_jobs
+        JobRepository._sequence = original_sequence
+        JobRepository._settings = original_settings
+
+
+def test_complete_task_job_returns_rate_and_updates_remaining():
+    job = JobRepository.create(
+        title="Task",
+        description="Complete a task",
+        pay_type="task",
+        pay_rate=Decimal("42.00"),
+        daily_limit=2,
+    )
+
+    updated_job, amount = JobRepository.complete_job(job.id)
+
+    assert amount == Decimal("42.00")
+    assert updated_job.completions_today == 1
+    assert updated_job.remaining_today == 1
+
+
+def test_time_job_rounds_up_to_nearest_cent():
+    job = JobRepository.create(
+        title="Shift",
+        description="Hourly work",
+        pay_type="time",
+        pay_rate=Decimal("20.00"),
+        daily_limit=None,
+    )
+
+    JobRepository.start_time_job(job.id)
+    job.active_session_started_at -= timedelta(minutes=10, seconds=10)
+
+    updated_job, amount = JobRepository.complete_job(job.id)
+
+    assert amount == Decimal("3.39")
+    assert updated_job.completions_today == 1
+    assert not updated_job.is_session_active
+    assert updated_job.active_session_seconds == 0
+
+
+def test_pause_and_resume_time_job_tracks_elapsed_time():
+    job = JobRepository.create(
+        title="Support",
+        description="Assist customers",
+        pay_type="time",
+        pay_rate=Decimal("18.00"),
+        daily_limit=3,
+    )
+
+    JobRepository.start_time_job(job.id)
+    job.active_session_started_at -= timedelta(minutes=5)
+    paused_job = JobRepository.pause_time_job(job.id)
+
+    assert paused_job.active_session_seconds >= 300
+    assert not paused_job.is_session_active
+
+    resumed_job = JobRepository.start_time_job(job.id)
+    assert resumed_job.is_session_active
+
+
+def test_cannot_start_time_job_after_limit_reached():
+    job = JobRepository.create(
+        title="Design",
+        description="Design session",
+        pay_type="time",
+        pay_rate=Decimal("30.00"),
+        daily_limit=1,
+    )
+
+    JobRepository.start_time_job(job.id)
+    job.active_session_started_at -= timedelta(minutes=15)
+    JobRepository.complete_job(job.id)
+
+    with pytest.raises(ValueError):
+        JobRepository.start_time_job(job.id)


### PR DESCRIPTION
## Summary
- track active job sessions and expose start, pause, and completion endpoints with modal confirmations and real-time earnings
- deposit task and time-based payouts into the selected cash, checking, or savings account using the payroll company name from settings
- refresh the job listings UI with new controls, modal styling, and coverage tests for the job service logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d118cf0ef88321816eaf05671a238f